### PR TITLE
add SPDX-License-Identifier for all source

### DIFF
--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `blkio` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module handles cgroup operations. Start here!
 
 use crate::error::*;

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module allows the user to create a control group using the Builder pattern.
 //! # Example
 //!

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `cpu` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `cpuacct` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `cpuset` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `devices` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 use std::error::Error as StdError;
 use std::fmt;
 

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `freezer` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module represents the various control group hierarchies the Linux kernel supports.
 //!
 //! Currently, we only support the cgroupv1 hierarchy, but in the future we will add support for

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `hugetlb` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 use log::*;
 
 use std::fs::File;

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `memory` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `net_cls` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `net_prio` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/perf_event.rs
+++ b/src/perf_event.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `perf_event` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `pids` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `rdma` cgroup subsystem.
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Some simple tests covering the builder pattern for control groups.
 use cgroups::*;
 use cgroups::cpu::*;

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Simple unit tests about the control groups system.
 use cgroups::{Cgroup, CgroupPid};
 

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 use cgroups::cpuset::CpuSetController;
 use cgroups::error::ErrorKind;
 use cgroups::Cgroup;

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Integration tests about the devices subsystem
 
 use cgroups::devices::{DevicePermissions, DeviceType, DevicesController};

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2018 Levente Kurusa
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Integration tests about the pids subsystem
 use cgroups::pid::{PidController, PidMax};
 use cgroups::Controller;

--- a/tools/create_cgroup.sh
+++ b/tools/create_cgroup.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2018 Levente Kurusa
+#
+# SPDX-License-Identifier: Apache-2.0 or MIT
+#
 
 CONTROL_GROUPS=`cargo test -- --list 2>/dev/null | egrep 'test$' | egrep -v '^src' | cut -d':' -f1`
 

--- a/tools/delete_cgroup.sh
+++ b/tools/delete_cgroup.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+#
+# Copyright (c) 2018 Levente Kurusa
+#
+# SPDX-License-Identifier: Apache-2.0 or MIT
+#
 
 CONTROL_GROUPS=`cargo test -- --list 2>/dev/null | egrep 'test$' | egrep -v '^src' | cut -d':' -f1`
 


### PR DESCRIPTION
Add SPDX-License-Identifier for all existing codes.

Fixes: #2

Signed-off-by: bin liu <bin@hyper.sh>