### PR TITLE
add cgroup v2 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2018"
 
 [dependencies]
 log = "0.4"
+regex = "1.1"
 
 [dev-dependencies]
 nix = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2018"
 log = "0.4"
 regex = "1.1"
 nix = "0.18.0"
+libc = "0.2"
 
 [dev-dependencies]
 libc = "0.2.76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 log = "0.4"
 regex = "1.1"
+nix = "0.18.0"
 
 [dev-dependencies]
-nix = "0.11.0"
-libc = "0.2.43"
+libc = "0.2.76"

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -338,19 +338,19 @@ impl ControllerInternal for BlkIoController {
         let res: &BlkIoResources = &res.blkio;
 
         if res.update_values {
-            if res.weight.is_some() {
-                let _ = self.set_weight(res.weight.unwrap() as u64);
+            if let Some(weight) = res.weight {
+                let _ = self.set_weight(weight as u64);
             }
-            if res.leaf_weight.is_some() {
-                let _ = self.set_leaf_weight(res.leaf_weight.unwrap() as u64);
+            if let Some(leaf_weight) = res.leaf_weight {
+                let _ = self.set_leaf_weight(leaf_weight as u64);
             }
 
             for dev in &res.weight_device {
-                if dev.weight.is_some(){
-                    let _ = self.set_weight_for_device(dev.major, dev.minor, dev.weight.unwrap() as u64);
+                if let Some(weight) = dev.weight {
+                    let _ = self.set_weight_for_device(dev.major, dev.minor, weight as u64);
                 }
-                if dev.leaf_weight.is_some(){
-                    let _ = self.set_leaf_weight_for_device(dev.major, dev.minor, dev.leaf_weight.unwrap() as u64);
+                if let Some(leaf_weight) = dev.leaf_weight {
+                    let _ = self.set_leaf_weight_for_device(dev.major, dev.minor, leaf_weight as u64);
                 }
             }
 
@@ -774,7 +774,7 @@ impl BlkIoController {
         let mut content = format!("{}:{} {}", major, minor, iops);
         if self.v2 {
             file = "io.max";
-            content = format!("{}:{} riops={}", major, minor, iops);
+            content = format!("{}:{} wiops={}", major, minor, iops);
         }
         self.open_path(file, true)
             .and_then(|mut file| {
@@ -785,7 +785,7 @@ impl BlkIoController {
 
     /// Set the weight of the control group's tasks.
     pub fn set_weight(&self, w: u64) -> Result<()> {
-        // FIXME: not find in high kernel version.
+        // Attation: may not find in high kernel version.
         let mut file = "blkio.weight";
         if self.v2 {
             file = "io.bfq.weight";
@@ -806,8 +806,9 @@ impl BlkIoController {
     ) -> Result<()> {
         let mut file = "blkio.weight_device";
         if self.v2 {
-            // FIXME why is there no weight for device in runc ?
+            // Attation: there is no weight for device in runc
             // https://github.com/opencontainers/runc/blob/46be7b612e2533c494e6a251111de46d8e286ed5/libcontainer/cgroups/fs2/io.go#L30
+            // may depends on IO schedulers https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers
             file = "io.bfq.weight";
         }
         self.open_path(file, true)

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -21,6 +21,7 @@ use crate::{
 pub struct BlkIoController {
     base: PathBuf,
     path: PathBuf,
+    v2:   bool,
 }
 
 #[derive(Eq, PartialEq, Debug)]
@@ -269,6 +270,10 @@ impl ControllerInternal for BlkIoController {
         &self.base
     }
 
+    fn is_v2(&self) -> bool {
+        self.v2
+    }
+
     fn apply(&self, res: &Resources) -> Result<()> {
         // get the resources that apply to this controller
         let res: &BlkIoResources = &res.blkio;
@@ -341,12 +346,15 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 
 impl BlkIoController {
     /// Constructs a new `BlkIoController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
+    pub fn new(oroot: PathBuf, v2: bool) -> Self {
         let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+        if !v2{
+            root.push(Self::controller_type().to_string());
+        }
         Self {
             base: root.clone(),
             path: root,
+            v2:   v2,
         }
     }
 

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -136,9 +136,11 @@ impl<'b> Cgroup<'b> {
     /// will change.
     pub fn delete(self) {
         if self.v2() {
-            let mut p = self.hier.root().clone();
-            p.push(self.path);
-            libc_rmdir(p.to_str().unwrap());
+            if self.path != "" {
+                let mut p = self.hier.root().clone();
+                p.push(self.path);
+                libc_rmdir(p.to_str().unwrap());
+            }
             return
         }
 

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -13,8 +13,9 @@
 //! # use cgroups::*;
 //! # use cgroups::devices::*;
 //! # use cgroups::cgroup_builder::*;
-//! let v1 = cgroups::hierarchies::V1::new();
-//! let cgroup: Cgroup = CgroupBuilder::new("hello", &v1)
+//! let h = cgroups::hierarchies::auto();
+//! let h = Box::new(&*h);
+//! let cgroup: Cgroup = CgroupBuilder::new("hello", h)
 //!      .memory()
 //!          .kernel_memory_limit(1024 * 1024)
 //!          .memory_hard_limit(1024 * 1024)
@@ -40,10 +41,10 @@
 //!          .limit("2G".to_string(), 2 * 1024 * 1024 * 1024)
 //!          .done()
 //!      .blkio()
-//!          .weight(123)
-//!          .leaf_weight(99)
-//!          .weight_device(6, 1, 100, 55)
-//!          .weight_device(6, 1, 100, 55)
+//!          .weight(Some(123))
+//!          .leaf_weight(Some(99))
+//!          .weight_device(6, 1, Some(100), Some(55))
+//!          .weight_device(6, 1, Some(100), Some(55))
 //!          .throttle_iops()
 //!              .read(6, 1, 10)
 //!              .write(11, 1, 100)
@@ -296,15 +297,15 @@ pub struct BlkIoResourcesBuilder<'a> {
 
 impl<'a> BlkIoResourcesBuilder<'a> {
 
-    gen_setter!(blkio, BlkIoController, set_weight, weight, u16);
-    gen_setter!(blkio, BlkIoController, set_leaf_weight, leaf_weight, u16);
+    gen_setter!(blkio, BlkIoController, set_weight, weight, Option<u16>);
+    gen_setter!(blkio, BlkIoController, set_leaf_weight, leaf_weight, Option<u16>);
 
     /// Set the weight of a certain device.
     pub fn weight_device(mut self,
                          major: u64,
                          minor: u64,
-                         weight: u16,
-                         leaf_weight: u16)
+                         weight: Option<u16>,
+                         leaf_weight: Option<u16>)
         -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
         self.cgroup.resources.blkio.weight_device.push(BlkIoDeviceResource {

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -62,7 +62,10 @@
 //! ```
 use crate::error::*;
 
-use crate::{pid, BlkIoDeviceResource, BlkIoDeviceThrottleResource,  Cgroup, DeviceResource, Hierarchy, HugePageResource, MaxValue, NetworkPriority, Resources};
+use crate::{
+    pid, BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, DeviceResource, Hierarchy,
+    HugePageResource, MaxValue, NetworkPriority, Resources,
+};
 
 macro_rules! gen_setter {
     ($res:ident, $cont:ident, $func:ident, $name:ident, $ty:ty) => {
@@ -72,7 +75,7 @@ macro_rules! gen_setter {
             self.cgroup.resources.$res.$name = $name;
             self
         }
-    }
+    };
 }
 
 /// A control group builder instance
@@ -97,46 +100,34 @@ impl<'a> CgroupBuilder<'a> {
 
     /// Builds the memory resources of the control group.
     pub fn memory(self) -> MemoryResourceBuilder<'a> {
-        MemoryResourceBuilder {
-            cgroup: self,
-        }
+        MemoryResourceBuilder { cgroup: self }
     }
 
     /// Builds the pid resources of the control group.
     pub fn pid(self) -> PidResourceBuilder<'a> {
-        PidResourceBuilder {
-            cgroup: self,
-        }
+        PidResourceBuilder { cgroup: self }
     }
 
     /// Builds the cpu resources of the control group.
     pub fn cpu(self) -> CpuResourceBuilder<'a> {
-        CpuResourceBuilder {
-            cgroup: self,
-        }
+        CpuResourceBuilder { cgroup: self }
     }
 
     /// Builds the devices resources of the control group, disallowing or
     /// allowing access to certain devices in the system.
     pub fn devices(self) -> DeviceResourceBuilder<'a> {
-        DeviceResourceBuilder {
-            cgroup: self,
-        }
+        DeviceResourceBuilder { cgroup: self }
     }
 
     /// Builds the network resources of the control group, setting class id, or
     /// various priorities on networking interfaces.
     pub fn network(self) -> NetworkResourceBuilder<'a> {
-        NetworkResourceBuilder {
-            cgroup: self,
-        }
+        NetworkResourceBuilder { cgroup: self }
     }
 
     /// Builds the hugepage/hugetlb resources available to the control group.
     pub fn hugepages(self) -> HugepagesResourceBuilder<'a> {
-        HugepagesResourceBuilder {
-            cgroup: self,
-        }
+        HugepagesResourceBuilder { cgroup: self }
     }
 
     /// Builds the block I/O resources available for the control group.
@@ -161,12 +152,35 @@ pub struct MemoryResourceBuilder<'a> {
 }
 
 impl<'a> MemoryResourceBuilder<'a> {
-
-    gen_setter!(memory, MemController, set_kmem_limit, kernel_memory_limit, i64);
+    gen_setter!(
+        memory,
+        MemController,
+        set_kmem_limit,
+        kernel_memory_limit,
+        i64
+    );
     gen_setter!(memory, MemController, set_limit, memory_hard_limit, i64);
-    gen_setter!(memory, MemController, set_soft_limit, memory_soft_limit, i64);
-    gen_setter!(memory, MemController, set_tcp_limit, kernel_tcp_memory_limit, i64);
-    gen_setter!(memory, MemController, set_memswap_limit, memory_swap_limit, i64);
+    gen_setter!(
+        memory,
+        MemController,
+        set_soft_limit,
+        memory_soft_limit,
+        i64
+    );
+    gen_setter!(
+        memory,
+        MemController,
+        set_tcp_limit,
+        kernel_tcp_memory_limit,
+        i64
+    );
+    gen_setter!(
+        memory,
+        MemController,
+        set_memswap_limit,
+        memory_swap_limit,
+        i64
+    );
     gen_setter!(memory, MemController, set_swappiness, swappiness, u64);
 
     /// Finish the construction of the memory resources of a control group.
@@ -181,8 +195,13 @@ pub struct PidResourceBuilder<'a> {
 }
 
 impl<'a> PidResourceBuilder<'a> {
-
-    gen_setter!(pid, PidController, set_pid_max, maximum_number_of_processes, MaxValue);
+    gen_setter!(
+        pid,
+        PidController,
+        set_pid_max,
+        maximum_number_of_processes,
+        MaxValue
+    );
 
     /// Finish the construction of the pid resources of a control group.
     pub fn done(self) -> CgroupBuilder<'a> {
@@ -196,7 +215,6 @@ pub struct CpuResourceBuilder<'a> {
 }
 
 impl<'a> CpuResourceBuilder<'a> {
-
     // FIXME this should all changed to options.
     gen_setter!(cpu, CpuSetController, set_cpus, cpus, Option<String>);
     gen_setter!(cpu, CpuSetController, set_mems, mems, String);
@@ -218,22 +236,22 @@ pub struct DeviceResourceBuilder<'a> {
 }
 
 impl<'a> DeviceResourceBuilder<'a> {
-
     /// Restrict (or allow) a device to the tasks inside the control group.
-    pub fn device(mut self,
-                  major: i64,
-                  minor: i64,
-                  devtype: crate::devices::DeviceType,
-                  allow: bool,
-                  access: Vec<crate::devices::DevicePermissions>)
-            -> DeviceResourceBuilder<'a> {
+    pub fn device(
+        mut self,
+        major: i64,
+        minor: i64,
+        devtype: crate::devices::DeviceType,
+        allow: bool,
+        access: Vec<crate::devices::DevicePermissions>,
+    ) -> DeviceResourceBuilder<'a> {
         self.cgroup.resources.devices.update_values = true;
         self.cgroup.resources.devices.devices.push(DeviceResource {
             major,
             minor,
             devtype,
             allow,
-            access
+            access,
         });
         self
     }
@@ -250,18 +268,17 @@ pub struct NetworkResourceBuilder<'a> {
 }
 
 impl<'a> NetworkResourceBuilder<'a> {
-
     gen_setter!(network, NetclsController, set_class, class_id, u64);
 
     /// Set the priority of the tasks when operating on a networking device defined by `name` to be
     /// `priority`.
-    pub fn priority(mut self, name: String, priority: u64)
-        -> NetworkResourceBuilder<'a> {
+    pub fn priority(mut self, name: String, priority: u64) -> NetworkResourceBuilder<'a> {
         self.cgroup.resources.network.update_values = true;
-        self.cgroup.resources.network.priorities.push(NetworkPriority {
-            name,
-            priority,
-        });
+        self.cgroup
+            .resources
+            .network
+            .priorities
+            .push(NetworkPriority { name, priority });
         self
     }
 
@@ -277,15 +294,14 @@ pub struct HugepagesResourceBuilder<'a> {
 }
 
 impl<'a> HugepagesResourceBuilder<'a> {
-
     /// Limit the usage of certain hugepages (determined by `size`) to be at most `limit` bytes.
-    pub fn limit(mut self, size: String, limit: u64)
-        -> HugepagesResourceBuilder<'a> {
+    pub fn limit(mut self, size: String, limit: u64) -> HugepagesResourceBuilder<'a> {
         self.cgroup.resources.hugepages.update_values = true;
-        self.cgroup.resources.hugepages.limits.push(HugePageResource {
-            size,
-            limit,
-        });
+        self.cgroup
+            .resources
+            .hugepages
+            .limits
+            .push(HugePageResource { size, limit });
         self
     }
 
@@ -302,24 +318,34 @@ pub struct BlkIoResourcesBuilder<'a> {
 }
 
 impl<'a> BlkIoResourcesBuilder<'a> {
-
     gen_setter!(blkio, BlkIoController, set_weight, weight, Option<u16>);
-    gen_setter!(blkio, BlkIoController, set_leaf_weight, leaf_weight, Option<u16>);
+    gen_setter!(
+        blkio,
+        BlkIoController,
+        set_leaf_weight,
+        leaf_weight,
+        Option<u16>
+    );
 
     /// Set the weight of a certain device.
-    pub fn weight_device(mut self,
-                         major: u64,
-                         minor: u64,
-                         weight: Option<u16>,
-                         leaf_weight: Option<u16>)
-        -> BlkIoResourcesBuilder<'a> {
+    pub fn weight_device(
+        mut self,
+        major: u64,
+        minor: u64,
+        weight: Option<u16>,
+        leaf_weight: Option<u16>,
+    ) -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
-        self.cgroup.resources.blkio.weight_device.push(BlkIoDeviceResource {
-            major,
-            minor,
-            weight,
-            leaf_weight,
-        });
+        self.cgroup
+            .resources
+            .blkio
+            .weight_device
+            .push(BlkIoDeviceResource {
+                major,
+                minor,
+                weight,
+                leaf_weight,
+            });
         self
     }
 
@@ -336,35 +362,41 @@ impl<'a> BlkIoResourcesBuilder<'a> {
     }
 
     /// Limit the read rate of the current metric for a certain device.
-    pub fn read(mut self, major: u64, minor: u64, rate: u64)
-        -> BlkIoResourcesBuilder<'a> {
+    pub fn read(mut self, major: u64, minor: u64, rate: u64) -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
-        let throttle = BlkIoDeviceThrottleResource {
-            major,
-            minor,
-            rate,
-        };
+        let throttle = BlkIoDeviceThrottleResource { major, minor, rate };
         if self.throttling_iops {
-            self.cgroup.resources.blkio.throttle_read_iops_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_read_iops_device
+                .push(throttle);
         } else {
-            self.cgroup.resources.blkio.throttle_read_bps_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_read_bps_device
+                .push(throttle);
         }
         self
     }
 
     /// Limit the write rate of the current metric for a certain device.
-    pub fn write(mut self, major: u64, minor: u64, rate: u64)
-        -> BlkIoResourcesBuilder<'a> {
+    pub fn write(mut self, major: u64, minor: u64, rate: u64) -> BlkIoResourcesBuilder<'a> {
         self.cgroup.resources.blkio.update_values = true;
-        let throttle = BlkIoDeviceThrottleResource {
-            major,
-            minor,
-            rate,
-        };
+        let throttle = BlkIoDeviceThrottleResource { major, minor, rate };
         if self.throttling_iops {
-            self.cgroup.resources.blkio.throttle_write_iops_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_write_iops_device
+                .push(throttle);
         } else {
-            self.cgroup.resources.blkio.throttle_write_bps_device.push(throttle);
+            self.cgroup
+                .resources
+                .blkio
+                .throttle_write_bps_device
+                .push(throttle);
         }
         self
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -13,8 +13,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
@@ -29,7 +29,7 @@ use crate::{
 pub struct CpuController {
     base: PathBuf,
     path: PathBuf,
-    v2:   bool,
+    v2: bool,
 }
 
 /// The current state of the control group and its processes.
@@ -112,7 +112,10 @@ impl<'a> From<&'a Subsystem> for &'a CpuController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -127,7 +130,7 @@ impl CpuController {
         Self {
             base: root.clone(),
             path: root,
-            v2:   v2,
+            v2: v2,
         }
     }
 
@@ -143,7 +146,8 @@ impl CpuController {
                         Ok(_) => Ok(s),
                         Err(e) => Err(Error::with_cause(ReadFailed, e)),
                     }
-                }).unwrap_or("".to_string()),
+                })
+                .unwrap_or("".to_string()),
         }
     }
 
@@ -215,22 +219,21 @@ impl CpuController {
             return self.set_cfs_period(period);
         }
         let mut line = "max".to_string();
-		if quota > 0 {
-			line = quota.to_string();
+        if quota > 0 {
+            line = quota.to_string();
         }
 
         let mut p = period;
-		if period == 0 {
-			// This default value is documented in
-			// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
-			p = 100000
-		}
+        if period == 0 {
+            // This default value is documented in
+            // https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+            p = 100000
+        }
         line = format!("{} {}", line, p);
-        self.open_path("cpu.max", true)
-            .and_then(|mut file| {
-                file.write_all(line.as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        self.open_path("cpu.max", true).and_then(|mut file| {
+            file.write_all(line.as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     pub fn set_rt_runtime(&self, us: i64) -> Result<()> {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -61,7 +61,6 @@ impl ControllerInternal for CpuController {
         let res: &CpuResources = &res.cpu;
 
         if res.update_values {
-            // apply pid_max
             let _ = self.set_shares(res.shares);
             if self.shares()? != res.shares as u64 {
                 return Err(Error::new(ErrorKind::Other));
@@ -163,7 +162,11 @@ impl CpuController {
     /// Retrieve the CPU bandwidth that this control group (relative to other control groups and
     /// this control group's parent) can use.
     pub fn shares(&self) -> Result<u64> {
-        self.open_path("cpu.shares", false).and_then(read_u64_from)
+        let mut file = "cpu.shares";
+        if self.v2 {
+            file = "cpu.weight";
+        }
+        self.open_path(file, false).and_then(read_u64_from)
     }
 
     /// Specify a period (when using the CFS scheduler) of time in microseconds for how often this

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -23,6 +23,7 @@ use crate::{
 pub struct CpuController {
     base: PathBuf,
     path: PathBuf,
+    v2:   bool,
 }
 
 /// The current state of the control group and its processes.
@@ -49,6 +50,10 @@ impl ControllerInternal for CpuController {
 
     fn get_base(&self) -> &PathBuf {
         &self.base
+    }
+
+    fn is_v2(&self) -> bool {
+        self.v2
     }
 
     fn apply(&self, res: &Resources) -> Result<()> {
@@ -109,12 +114,15 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 
 impl CpuController {
     /// Contructs a new `CpuController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
+    pub fn new(oroot: PathBuf, v2: bool) -> Self {
         let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+        if !v2 {
+            root.push(Self::controller_type().to_string());
+        }
         Self {
             base: root.clone(),
             path: root,
+            v2:   v2,
         }
     }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -149,7 +149,12 @@ impl CpuController {
     /// `shares` to `200` ensures that control group `B` receives twice as much as CPU bandwidth.
     /// (Assuming both `A` and `B` are of the same parent)
     pub fn set_shares(&self, shares: u64) -> Result<()> {
-        self.open_path("cpu.shares", true).and_then(|mut file| {
+        let mut file = "cpu.shares";
+        if self.v2 {
+            file = "cpu.weight";
+        }
+        // NOTE: .CpuShares is not used here. Conversion is the caller's responsibility.
+        self.open_path(file, true).and_then(|mut file| {
             file.write_all(shares.to_string().as_ref())
                 .map_err(|e| Error::with_cause(WriteFailed, e))
         })
@@ -193,5 +198,45 @@ impl CpuController {
     pub fn cfs_quota(&self) -> Result<u64> {
         self.open_path("cpu.cfs_quota_us", false)
             .and_then(read_u64_from)
+    }
+
+    pub fn set_cfs_quota_and_period(&self, quota: u64, period: u64) -> Result<()> {
+        if !self.v2 {
+            self.set_cfs_quota(quota)?;
+            return self.set_cfs_period(period);
+        }
+        let mut line = "max".to_string();
+		if quota > 0 {
+			line = quota.to_string();
+        }
+
+        let mut p = period;
+		if period == 0 {
+			// This default value is documented in
+			// https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html
+			p = 100000
+		}
+        line = format!("{} {}", line, p);
+        self.open_path("cpu.max", true)
+            .and_then(|mut file| {
+                file.write_all(line.as_ref())
+                    .map_err(|e| Error::with_cause(WriteFailed, e))
+            })
+    }
+
+    pub fn set_rt_runtime(&self, us: i64) -> Result<()> {
+        self.open_path("cpu.rt_runtime_us", true)
+            .and_then(|mut file| {
+                file.write_all(us.to_string().as_ref())
+                    .map_err(|e| Error::with_cause(WriteFailed, e))
+            })
+    }
+
+    pub fn set_rt_period_us(&self, us: u64) -> Result<()> {
+        self.open_path("cpu.rt_period_us", true)
+            .and_then(|mut file| {
+                file.write_all(us.to_string().as_ref())
+                    .map_err(|e| Error::with_cause(WriteFailed, e))
+            })
     }
 }

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -11,8 +11,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
@@ -167,7 +167,9 @@ impl CpuAcctController {
 
     /// Reset the statistics the kernel has gathered about the control group.
     pub fn reset(&self) -> Result<()> {
-        self.open_path("cpuacct.usage", true)
-            .and_then(|mut file| file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e)))
+        self.open_path("cpuacct.usage", true).and_then(|mut file| {
+            file.write_all(b"0")
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -14,8 +14,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
@@ -29,7 +29,7 @@ use crate::{
 pub struct CpuSetController {
     base: PathBuf,
     path: PathBuf,
-    v2:   bool,
+    v2: bool,
 }
 
 /// The current state of the `cpuset` controller for this control group.
@@ -111,7 +111,7 @@ impl ControllerInternal for CpuSetController {
         let res: &CpuResources = &res.cpu;
 
         if res.update_values {
-            if res.cpus.is_some(){
+            if res.cpus.is_some() {
                 let _ = self.set_cpus(res.cpus.as_ref().unwrap().as_str());
             }
             let _ = self.set_mems(&res.mems);
@@ -120,9 +120,9 @@ impl ControllerInternal for CpuSetController {
         Ok(())
     }
 
-    fn post_create(&self){
-        if self.is_v2(){
-            return
+    fn post_create(&self) {
+        if self.is_v2() {
+            return;
         }
         let current = self.get_path();
         let parent = match current.parent() {
@@ -132,11 +132,11 @@ impl ControllerInternal for CpuSetController {
 
         if current != self.get_base() {
             match copy_from_parent(current.to_str().unwrap(), "cpuset.cpus") {
-                Ok(_)=>(),
+                Ok(_) => (),
                 Err(err) => error!("error create_dir for cpuset.cpus {:?}", err),
             }
             match copy_from_parent(current.to_str().unwrap(), "cpuset.mems") {
-                Ok(_)=>(),
+                Ok(_) => (),
                 Err(err) => error!("error create_dir for cpuset.mems {:?}", err),
             }
         }
@@ -148,10 +148,11 @@ fn find_no_empty_parent(from: &str, file: &str) -> Result<(String, Vec<PathBuf>)
     let mut v = vec![];
 
     loop {
-        let current_value = match ::std::fs::read_to_string(current_path.clone().join(file).to_str().unwrap()) {
-            Ok(cpus) => String::from(cpus.trim()),
-            Err(e) => return Err(Error::with_cause(ReadFailed, e)),
-        };
+        let current_value =
+            match ::std::fs::read_to_string(current_path.clone().join(file).to_str().unwrap()) {
+                Ok(cpus) => String::from(cpus.trim()),
+                Err(e) => return Err(Error::with_cause(ReadFailed, e)),
+            };
 
         if current_value != "" {
             return Ok((current_value, v));
@@ -221,7 +222,10 @@ fn read_string_from(mut file: File) -> Result<String> {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -267,7 +271,7 @@ impl CpuSetController {
     /// Contructs a new `CpuSetController` with `oroot` serving as the root of the control group.
     pub fn new(oroot: PathBuf, v2: bool) -> Self {
         let mut root = oroot;
-        if !v2{
+        if !v2 {
             root.push(Self::controller_type().to_string());
         }
         Self {
@@ -372,9 +376,11 @@ impl CpuSetController {
         self.open_path("cpuset.cpu_exclusive", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -385,9 +391,11 @@ impl CpuSetController {
         self.open_path("cpuset.mem_exclusive", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -422,9 +430,11 @@ impl CpuSetController {
         self.open_path("cpuset.mem_hardwall", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -435,9 +445,11 @@ impl CpuSetController {
         self.open_path("cpuset.sched_load_balance", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -459,9 +471,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_migrate", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -472,9 +486,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_spread_page", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -485,9 +501,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_spread_slab", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }
@@ -504,9 +522,11 @@ impl CpuSetController {
         self.open_path("cpuset.memory_pressure_enabled", true)
             .and_then(|mut file| {
                 if b {
-                    file.write_all(b"1").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"1")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 } else {
-                    file.write_all(b"0").map_err(|e| Error::with_cause(WriteFailed, e))
+                    file.write_all(b"0")
+                        .map_err(|e| Error::with_cause(WriteFailed, e))
                 }
             })
     }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -12,8 +12,8 @@ use std::path::PathBuf;
 
 use log::*;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, DeviceResource, DeviceResources,
@@ -129,8 +129,7 @@ impl DevicePermissions {
             return Ok(v);
         }
         for e in s.chars() {
-            let perm = DevicePermissions::from_char(e)
-                .ok_or_else(|| Error::new(ParseError))?;
+            let perm = DevicePermissions::from_char(e).ok_or_else(|| Error::new(ParseError))?;
             v.push(perm);
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ pub enum ErrorKind {
     /// This crate checks against this and operations will fail with this error.
     InvalidPath,
 
+    InvalidBytesSize,
+
     /// An unknown error has occured.
     Other,
 }
@@ -45,6 +47,7 @@ impl fmt::Display for Error {
             ErrorKind::ParseError => "unable to parse control group file",
             ErrorKind::InvalidOperation => "the requested operation is invalid",
             ErrorKind::InvalidPath => "the given path is invalid",
+            ErrorKind::InvalidBytesSize => "invalid bytes size",
             ErrorKind::Other => "an unknown error",
         };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,10 +83,7 @@ impl Error {
         }
     }
     pub(crate) fn new(kind: ErrorKind) -> Self {
-        Self {
-            kind,
-            cause: None,
-        }
+        Self { kind, cause: None }
     }
 
     pub(crate) fn with_cause<E>(kind: ErrorKind, cause: E) -> Self

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,9 @@ use std::fmt;
 /// The different types of errors that can occur while manipulating control groups.
 #[derive(Debug, Eq, PartialEq)]
 pub enum ErrorKind {
+    FsError,
+    Common(String),
+
     /// An error occured while writing to a control group file.
     WriteFailed,
 
@@ -41,14 +44,16 @@ pub struct Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let msg = match self.kind {
-            ErrorKind::WriteFailed => "unable to write to a control group file",
-            ErrorKind::ReadFailed => "unable to read a control group file",
-            ErrorKind::ParseError => "unable to parse control group file",
-            ErrorKind::InvalidOperation => "the requested operation is invalid",
-            ErrorKind::InvalidPath => "the given path is invalid",
-            ErrorKind::InvalidBytesSize => "invalid bytes size",
-            ErrorKind::Other => "an unknown error",
+        let msg = match &self.kind {
+            ErrorKind::FsError => "fs error".to_string(),
+            ErrorKind::Common(s) => s.clone(),
+            ErrorKind::WriteFailed => "unable to write to a control group file".to_string(),
+            ErrorKind::ReadFailed => "unable to read a control group file".to_string(),
+            ErrorKind::ParseError => "unable to parse control group file".to_string(),
+            ErrorKind::InvalidOperation => "the requested operation is invalid".to_string(),
+            ErrorKind::InvalidPath => "the given path is invalid".to_string(),
+            ErrorKind::InvalidBytesSize => "invalid bytes size".to_string(),
+            ErrorKind::Other => "an unknown error".to_string(),
         };
 
         write!(f, "{}", msg)
@@ -65,6 +70,12 @@ impl StdError for Error {
 }
 
 impl Error {
+    pub(crate) fn from_string(s: String) -> Self {
+        Self {
+            kind: ErrorKind::Common(s),
+            cause: None,
+        }
+    }
     pub(crate) fn new(kind: ErrorKind) -> Self {
         Self {
             kind,

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,0 +1,83 @@
+use eventfd::{eventfd, EfdFlags};
+use nix::sys::eventfd;
+use std::fs::{self, File};
+use std::io::Read;
+use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::path::{Path, PathBuf};
+use std::sync::mpsc::{self, Receiver};
+use std::thread;
+
+use crate::error::*;
+use crate::error::ErrorKind::*;
+
+
+// notify_on_oom returns channel on which you can expect event about OOM,
+// if process died without OOM this channel will be closed.
+pub fn notify_on_oom_v2(key: &str, dir: &PathBuf) -> Result<Receiver<String>> {
+    register_memory_event(key, dir, "memory.oom_control", "")
+}
+
+// notify_on_oom returns channel on which you can expect event about OOM,
+// if process died without OOM this channel will be closed.
+pub fn notify_on_oom_v1(key: &str, dir: &PathBuf) -> Result<Receiver<String>> {
+    register_memory_event(key, dir, "memory.oom_control", "")
+}
+
+// level is one of "low", "medium", or "critical"
+fn notify_memory_pressure(key: &str, dir: &PathBuf, level: &str) -> Result<Receiver<String>> {
+    if level != "low" && level != "medium" && level != "critical" {
+        return Err(Error::from_string(format!("invalid pressure level {}", level)));
+    }
+
+    register_memory_event(key, dir, "memory.pressure_level", level)
+}
+
+fn register_memory_event(
+    key: &str,
+    cg_dir: &PathBuf,
+    event_name: &str,
+    arg: &str,
+) -> Result<Receiver<String>> {
+    let path = cg_dir.join(event_name);
+    let event_file = File::open(path).map_err(|e| Error::with_cause(ReadFailed, e))?;
+
+    let eventfd = eventfd(0, EfdFlags::EFD_CLOEXEC).map_err(|e| Error::with_cause(ReadFailed, e))?;
+
+    let event_control_path = cg_dir.join("cgroup.event_control");
+    let data;
+    if arg == "" {
+        data = format!("{} {}", eventfd, event_file.as_raw_fd());
+    } else {
+        data = format!("{} {} {}", eventfd, event_file.as_raw_fd(), arg);
+    }
+
+    // write to file and set mode to 0700(FIXME)
+    fs::write(&event_control_path, data).map_err(|e| Error::with_cause(WriteFailed, e));
+
+    let mut eventfd_file = unsafe { File::from_raw_fd(eventfd) };
+
+    let (sender, receiver) = mpsc::channel();
+    let key = key.to_string();
+
+    thread::spawn(move || {
+        loop {
+            let mut buf = [0; 8];
+            match eventfd_file.read(&mut buf) {
+                Err(err) => {
+                    return;
+                }
+                Ok(_) => {
+                }
+            }
+
+            // When a cgroup is destroyed, an event is sent to eventfd.
+            // So if the control path is gone, return instead of notifying.
+            if !Path::new(&event_control_path).exists() {
+                return;
+            }
+            sender.send(key.clone()).unwrap();
+        }
+    });
+
+    Ok(receiver)
+}

--- a/src/events.rs
+++ b/src/events.rs
@@ -12,9 +12,8 @@ use std::path::{Path, PathBuf};
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
-
+use crate::error::*;
 
 // notify_on_oom returns channel on which you can expect event about OOM,
 // if process died without OOM this channel will be closed.
@@ -31,7 +30,10 @@ pub fn notify_on_oom_v1(key: &str, dir: &PathBuf) -> Result<Receiver<String>> {
 // level is one of "low", "medium", or "critical"
 pub fn notify_memory_pressure(key: &str, dir: &PathBuf, level: &str) -> Result<Receiver<String>> {
     if level != "low" && level != "medium" && level != "critical" {
-        return Err(Error::from_string(format!("invalid pressure level {}", level)));
+        return Err(Error::from_string(format!(
+            "invalid pressure level {}",
+            level
+        )));
     }
 
     register_memory_event(key, dir, "memory.pressure_level", level)
@@ -46,7 +48,8 @@ fn register_memory_event(
     let path = cg_dir.join(event_name);
     let event_file = File::open(path).map_err(|e| Error::with_cause(ReadFailed, e))?;
 
-    let eventfd = eventfd(0, EfdFlags::EFD_CLOEXEC).map_err(|e| Error::with_cause(ReadFailed, e))?;
+    let eventfd =
+        eventfd(0, EfdFlags::EFD_CLOEXEC).map_err(|e| Error::with_cause(ReadFailed, e))?;
 
     let event_control_path = cg_dir.join("cgroup.event_control");
     let data;
@@ -71,8 +74,7 @@ fn register_memory_event(
                 Err(err) => {
                     return;
                 }
-                Ok(_) => {
-                }
+                Ok(_) => {}
             }
 
             // When a cgroup is destroyed, an event is sent to eventfd.

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2020 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 use eventfd::{eventfd, EfdFlags};
 use nix::sys::eventfd;
 use std::fs::{self, File};

--- a/src/events.rs
+++ b/src/events.rs
@@ -24,7 +24,7 @@ pub fn notify_on_oom_v1(key: &str, dir: &PathBuf) -> Result<Receiver<String>> {
 }
 
 // level is one of "low", "medium", or "critical"
-fn notify_memory_pressure(key: &str, dir: &PathBuf, level: &str) -> Result<Receiver<String>> {
+pub fn notify_memory_pressure(key: &str, dir: &PathBuf, level: &str) -> Result<Receiver<String>> {
     if level != "low" && level != "medium" && level != "critical" {
         return Err(Error::from_string(format!("invalid pressure level {}", level)));
     }

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -11,8 +11,8 @@
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
@@ -28,7 +28,7 @@ use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subs
 pub struct FreezerController {
     base: PathBuf,
     path: PathBuf,
-    v2:    bool,
+    v2: bool,
 }
 
 /// The current state of the control group
@@ -90,7 +90,7 @@ impl FreezerController {
         Self {
             base: root.clone(),
             path: root,
-            v2:   v2,
+            v2: v2,
         }
     }
 

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -45,7 +45,6 @@ pub struct V2 {
 }
 
 impl Hierarchy for V1 {
-
     fn v2(&self) -> bool {
         false
     }
@@ -71,7 +70,10 @@ impl Hierarchy for V1 {
             subs.push(Subsystem::Devices(DevicesController::new(self.root())));
         }
         if self.check_support(Controllers::Freezer) {
-            subs.push(Subsystem::Freezer(FreezerController::new(self.root(), false)));
+            subs.push(Subsystem::Freezer(FreezerController::new(
+                self.root(),
+                false,
+            )));
         }
         if self.check_support(Controllers::NetCls) {
             subs.push(Subsystem::NetCls(NetClsController::new(self.root())));
@@ -86,20 +88,26 @@ impl Hierarchy for V1 {
             subs.push(Subsystem::NetPrio(NetPrioController::new(self.root())));
         }
         if self.check_support(Controllers::HugeTlb) {
-            subs.push(Subsystem::HugeTlb(HugeTlbController::new(self.root(), false)));
+            subs.push(Subsystem::HugeTlb(HugeTlbController::new(
+                self.root(),
+                false,
+            )));
         }
         if self.check_support(Controllers::Rdma) {
             subs.push(Subsystem::Rdma(RdmaController::new(self.root())));
         }
         if self.check_support(Controllers::Systemd) {
-            subs.push(Subsystem::Systemd(SystemdController::new(self.root(), false)));
+            subs.push(Subsystem::Systemd(SystemdController::new(
+                self.root(),
+                false,
+            )));
         }
 
         subs
     }
 
     fn root_control_group(&self) -> Cgroup {
-        let b : &Hierarchy = self as &Hierarchy;
+        let b: &Hierarchy = self as &Hierarchy;
         Cgroup::load(Box::new(&*b), "".to_string())
     }
 
@@ -136,17 +144,37 @@ impl Hierarchy for V2 {
 
         let controllers = ret.unwrap().trim().to_string();
         let controller_list: Vec<&str> = controllers.split(' ').collect();
-        
+
         for s in controller_list {
             match s {
-                "cpu" => {subs.push(Subsystem::Cpu(CpuController::new(self.root(), true)));},
-                "io" => {subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), true)));},
-                "cpuset" => {subs.push(Subsystem::CpuSet(CpuSetController::new(self.root(), true)));},
-                "memory" => {subs.push(Subsystem::Mem(MemController::new(self.root(), true)));},
-                "pids" => {subs.push(Subsystem::Pid(PidController::new(self.root(), true)));},
-                "freezer" => {subs.push(Subsystem::Freezer(FreezerController::new(self.root(), true)));},
-                "hugetlb" => {subs.push(Subsystem::HugeTlb(HugeTlbController::new(self.root(), true)));},
-                _ => {},
+                "cpu" => {
+                    subs.push(Subsystem::Cpu(CpuController::new(self.root(), true)));
+                }
+                "io" => {
+                    subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), true)));
+                }
+                "cpuset" => {
+                    subs.push(Subsystem::CpuSet(CpuSetController::new(self.root(), true)));
+                }
+                "memory" => {
+                    subs.push(Subsystem::Mem(MemController::new(self.root(), true)));
+                }
+                "pids" => {
+                    subs.push(Subsystem::Pid(PidController::new(self.root(), true)));
+                }
+                "freezer" => {
+                    subs.push(Subsystem::Freezer(FreezerController::new(
+                        self.root(),
+                        true,
+                    )));
+                }
+                "hugetlb" => {
+                    subs.push(Subsystem::HugeTlb(HugeTlbController::new(
+                        self.root(),
+                        true,
+                    )));
+                }
+                _ => {}
             }
         }
 
@@ -154,7 +182,7 @@ impl Hierarchy for V2 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        let b : &Hierarchy = self as &Hierarchy;
+        let b: &Hierarchy = self as &Hierarchy;
         Cgroup::load(Box::new(&*b), "".to_string())
     }
 
@@ -195,7 +223,7 @@ pub fn is_cgroup2_unified_mode() -> bool {
     let path = Path::new(UNIFIED_MOUNTPOINT);
     let fs_stat = statfs::statfs(path);
     if fs_stat.is_err() {
-        return false
+        return false;
     }
 
     // FIXME notwork, nix will not compile CGROUP2_SUPER_MAGIC because not(target_env = "musl")
@@ -208,10 +236,10 @@ pub const INIT_CGROUP_PATHS: &'static str = "/proc/1/cgroup";
 pub fn is_cgroup2_unified_mode() -> bool {
     let lines = fs::read_to_string(INIT_CGROUP_PATHS);
     if lines.is_err() {
-        return false
+        return false;
     }
 
-    for line in lines.unwrap().lines(){
+    for line in lines.unwrap().lines() {
         let fields: Vec<&str> = line.split(':').collect();
         if fields.len() != 3 {
             continue;
@@ -227,7 +255,7 @@ pub fn is_cgroup2_unified_mode() -> bool {
 pub fn auto() -> Box<dyn Hierarchy> {
     if is_cgroup2_unified_mode() {
         Box::new(V2::new())
-    }else{
+    } else {
         Box::new(V1::new())
     }
 }

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -2,8 +2,9 @@
 //!
 //! Currently, we only support the cgroupv1 hierarchy, but in the future we will add support for
 //! the Unified Hierarchy.
+use nix::sys::statfs;
 
-use std::fs::File;
+use std::fs::{self, File};
 use std::io::BufRead;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
@@ -32,23 +33,32 @@ pub struct V1 {
     mount_point: String,
 }
 
+pub struct V2 {
+    root: String,
+}
+
 impl Hierarchy for V1 {
+
+    fn v2(&self) -> bool {
+        false
+    }
+
     fn subsystems(&self) -> Vec<Subsystem> {
         let mut subs = vec![];
         if self.check_support(Controllers::Pids) {
-            subs.push(Subsystem::Pid(PidController::new(self.root())));
+            subs.push(Subsystem::Pid(PidController::new(self.root(), false)));
         }
         if self.check_support(Controllers::Mem) {
-            subs.push(Subsystem::Mem(MemController::new(self.root())));
+            subs.push(Subsystem::Mem(MemController::new(self.root(), false)));
         }
         if self.check_support(Controllers::CpuSet) {
-            subs.push(Subsystem::CpuSet(CpuSetController::new(self.root())));
+            subs.push(Subsystem::CpuSet(CpuSetController::new(self.root(), false)));
         }
         if self.check_support(Controllers::CpuAcct) {
             subs.push(Subsystem::CpuAcct(CpuAcctController::new(self.root())));
         }
         if self.check_support(Controllers::Cpu) {
-            subs.push(Subsystem::Cpu(CpuController::new(self.root())));
+            subs.push(Subsystem::Cpu(CpuController::new(self.root(), false)));
         }
         if self.check_support(Controllers::Devices) {
             subs.push(Subsystem::Devices(DevicesController::new(self.root())));
@@ -60,7 +70,7 @@ impl Hierarchy for V1 {
             subs.push(Subsystem::NetCls(NetClsController::new(self.root())));
         }
         if self.check_support(Controllers::BlkIo) {
-            subs.push(Subsystem::BlkIo(BlkIoController::new(self.root())));
+            subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), true)));
         }
         if self.check_support(Controllers::PerfEvent) {
             subs.push(Subsystem::PerfEvent(PerfEventController::new(self.root())));
@@ -69,7 +79,7 @@ impl Hierarchy for V1 {
             subs.push(Subsystem::NetPrio(NetPrioController::new(self.root())));
         }
         if self.check_support(Controllers::HugeTlb) {
-            subs.push(Subsystem::HugeTlb(HugeTlbController::new(self.root())));
+            subs.push(Subsystem::HugeTlb(HugeTlbController::new(self.root(), false)));
         }
         if self.check_support(Controllers::Rdma) {
             subs.push(Subsystem::Rdma(RdmaController::new(self.root())));
@@ -79,7 +89,8 @@ impl Hierarchy for V1 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        Cgroup::load(self, "".to_string())
+        let b : &Hierarchy = self as &Hierarchy;
+        Cgroup::load(Box::new(&*b), "".to_string())
     }
 
     fn check_support(&self, sub: Controllers) -> bool {
@@ -99,14 +110,116 @@ impl Hierarchy for V1 {
     }
 }
 
+impl Hierarchy for V2 {
+    fn v2(&self) -> bool {
+        true
+    }
+
+    fn subsystems(&self) -> Vec<Subsystem> {
+        let mut subs = vec![];
+
+        let p = format!("{}/{}", UNIFIED_MOUNTPOINT, "cgroup.controllers");
+        let ret = fs::read_to_string(p.as_str());
+        if ret.is_err() {
+            return subs;
+        }
+
+        let controllers = ret.unwrap().trim().to_string();
+        println!("controllers: {:?}", controllers);
+
+        let controller_list: Vec<&str> = controllers.split(' ').collect();
+        
+        for s in controller_list {
+            match s {
+                "cpu" => {subs.push(Subsystem::Cpu(CpuController::new(self.root(), true)));},
+                "io" => {subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), true)));},
+                "cpuset" => {subs.push(Subsystem::CpuSet(CpuSetController::new(self.root(), true)));},
+                "memory" => {subs.push(Subsystem::Mem(MemController::new(self.root(), true)));},
+                "pids" => {subs.push(Subsystem::Pid(PidController::new(self.root(), true)));},
+                _ => {},
+            }
+        }
+
+        if self.check_support(Controllers::CpuAcct) {
+            subs.push(Subsystem::CpuAcct(CpuAcctController::new(self.root())));
+        }
+        if self.check_support(Controllers::Devices) {
+            subs.push(Subsystem::Devices(DevicesController::new(self.root())));
+        }
+        if self.check_support(Controllers::Freezer) {
+            subs.push(Subsystem::Freezer(FreezerController::new(self.root())));
+        }
+        if self.check_support(Controllers::NetCls) {
+            subs.push(Subsystem::NetCls(NetClsController::new(self.root())));
+        }
+        if self.check_support(Controllers::PerfEvent) {
+            subs.push(Subsystem::PerfEvent(PerfEventController::new(self.root())));
+        }
+        if self.check_support(Controllers::NetPrio) {
+            subs.push(Subsystem::NetPrio(NetPrioController::new(self.root())));
+        }
+        if self.check_support(Controllers::HugeTlb) {
+            subs.push(Subsystem::HugeTlb(HugeTlbController::new(self.root(), true)));
+        }
+        if self.check_support(Controllers::Rdma) {
+            subs.push(Subsystem::Rdma(RdmaController::new(self.root())));
+        }
+
+        subs
+    }
+
+    fn root_control_group(&self) -> Cgroup {
+        let b : &Hierarchy = self as &Hierarchy;
+        Cgroup::load(Box::new(&*b), "".to_string())
+    }
+
+    fn check_support(&self, _sub: Controllers) -> bool {
+        return false;
+    }
+
+    fn root(&self) -> PathBuf {
+        PathBuf::from(self.root.clone())
+    }
+}
+
 impl V1 {
     /// Finds where control groups are mounted to and returns a hierarchy in which control groups
     /// can be created.
-    pub fn new() -> Self {
+    pub fn new() -> V1 {
         let mount_point = find_v1_mount().unwrap();
         V1 {
             mount_point: mount_point,
         }
+    }
+}
+
+impl V2 {
+    /// Finds where control groups are mounted to and returns a hierarchy in which control groups
+    /// can be created.
+    pub fn new() -> V2 {
+        V2 {
+            root: String::from(UNIFIED_MOUNTPOINT),
+        }
+    }
+}
+
+pub const UNIFIED_MOUNTPOINT: &'static str = "/sys/fs/cgroup";
+
+pub fn is_cgroup2_unified_mode() -> bool {
+    let path = Path::new(UNIFIED_MOUNTPOINT);
+    let fs_stat = statfs::statfs(path);
+    if fs_stat.is_err() {
+        return false
+    }
+
+    fs_stat.unwrap().filesystem_type() == statfs::CGROUP2_SUPER_MAGIC
+}
+
+pub fn auto() -> Box<dyn Hierarchy> {
+    if is_cgroup2_unified_mode() {
+        Box::new(V2::new())
+    }else{
+        Box::new(V1::new())
     }
 }
 
@@ -125,7 +238,7 @@ fn find_v1_mount() -> Option<String> {
         let line = _line.unwrap();
         let mut fields = line.split_whitespace();
         let index = line.find(" - ").unwrap();
-        let mut more_fields = line[index + 3..].split_whitespace().collect::<Vec<_>>();
+        let more_fields = line[index + 3..].split_whitespace().collect::<Vec<_>>();
         if more_fields.len() == 0 {
             continue;
         }

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -126,11 +126,21 @@ fn find_v1_mount() -> Option<String> {
         let mut fields = line.split_whitespace();
         let index = line.find(" - ").unwrap();
         let mut more_fields = line[index + 3..].split_whitespace().collect::<Vec<_>>();
-        let fstype = more_fields[0];
-        if fstype == "tmpfs" && more_fields[2].contains("ro") {
+        if more_fields.len() == 0 {
+            continue;
+        }
+        if more_fields[0] == "cgroup" {
+            if more_fields.len() < 3 {
+                continue;
+            }
             let cgroups_mount = fields.nth(4).unwrap();
-            info!("found cgroups at {:?}", cgroups_mount);
-            return Some(cgroups_mount.to_string());
+            if let Some(parent) = std::path::Path::new(cgroups_mount).parent() {
+                if let Some(path) = parent.as_os_str().to_str() {
+                    debug!("found cgroups {:?} from {:?}", path, cgroups_mount);
+                    return Some(path.to_string());
+                }
+            }
+            continue;
         }
     }
 

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -23,6 +23,7 @@ pub struct HugeTlbController {
     base:  PathBuf,
     path:  PathBuf,
     sizes: Vec<String>,
+    v2:    bool,
 }
 
 impl ControllerInternal for HugeTlbController {
@@ -37,6 +38,10 @@ impl ControllerInternal for HugeTlbController {
     }
     fn get_base(&self) -> &PathBuf {
         &self.base
+    }
+
+    fn is_v2(&self) -> bool {
+        self.v2
     }
 
     fn apply(&self, res: &Resources) -> Result<()> {
@@ -85,14 +90,17 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 
 impl HugeTlbController {
     /// Constructs a new `HugeTlbController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
+    pub fn new(oroot: PathBuf, v2: bool) -> Self {
         let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+        if !v2 {
+            root.push(Self::controller_type().to_string());
+        }
         let sizes = get_hugepage_sizes().unwrap();
         Self {
             base: root.clone(),
             path: root,
             sizes: sizes,
+            v2:   v2,
         }
     }
 

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,7 +233,7 @@ impl<T> Controller for T where T: ControllerInternal {
     fn create(&self) {
         self.verify_path().expect("path should be valid");
 
-        match ::std::fs::create_dir(self.get_path()) {
+        match ::std::fs::create_dir_all(self.get_path()) {
             Ok(_) => self.post_create(),
             Err(e) => warn!("error create_dir {:?}", e),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,11 @@ mod sealed {
         fn get_path_mut(&mut self) -> &mut PathBuf;
         fn get_base(&self) -> &PathBuf;
 
+        /// Hooks running after controller crated, if have
+        fn post_create(&self){
+        }
+
+
         fn verify_path(&self) -> Result<()> {
             if self.get_path().starts_with(self.get_base()) {
                 Ok(())
@@ -211,7 +216,7 @@ impl<T> Controller for T where T: ControllerInternal {
         self.verify_path().expect("path should be valid");
 
         match ::std::fs::create_dir(self.get_path()) {
-            Ok(_) => (),
+            Ok(_) => self.post_create(),
             Err(e) => warn!("error create_dir {:?}", e),
         }
     }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::sync::mpsc::{Receiver};
+use std::sync::mpsc::Receiver;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
@@ -21,7 +21,8 @@ use crate::events;
 use crate::flat_keyed_to_hashmap;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, MaxValue, MemoryResources, Resources, Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, MaxValue, MemoryResources, Resources,
+    Subsystem,
 };
 
 /// A controller that allows controlling the `memory` subsystem of a Cgroup.
@@ -33,9 +34,8 @@ use crate::{
 pub struct MemController {
     base: PathBuf,
     path: PathBuf,
-    v2:   bool,
+    v2: bool,
 }
-
 
 #[derive(Default, Debug, PartialEq, Eq)]
 pub struct SetMemory {
@@ -476,25 +476,29 @@ impl MemController {
         Self {
             base: root.clone(),
             path: root,
-            v2:   v2,
+            v2: v2,
         }
     }
 
     // for v2
-    pub fn set_mem(&self, m: SetMemory) ->  Result<()> {
-        let values = vec![(m.high, "memory.high"),(m.low, "memory.low"),(m.max, "memory.max"),(m.min, "memory.min")];
-        for value in values{
+    pub fn set_mem(&self, m: SetMemory) -> Result<()> {
+        let values = vec![
+            (m.high, "memory.high"),
+            (m.low, "memory.low"),
+            (m.max, "memory.max"),
+            (m.min, "memory.min"),
+        ];
+        for value in values {
             let v = value.0;
             let f = value.1;
             if v.is_some() {
                 let v = v.unwrap().to_string();
-                self.open_path(f, true)
-                .and_then(|mut file| {
+                self.open_path(f, true).and_then(|mut file| {
                     file.write_all(v.as_ref())
                         .map_err(|e| Error::with_cause(WriteFailed, e))
                 })?;
             }
-            }
+        }
         Ok(())
     }
 
@@ -652,9 +656,8 @@ impl MemController {
             fail_cnt: self
                 .open_path("memory.swap.events", false)
                 .and_then(flat_keyed_to_hashmap)
-                .and_then(|x| {
-                    Ok(*x.get("fail").unwrap_or(&0) as u64)
-                }).unwrap(),
+                .and_then(|x| Ok(*x.get("fail").unwrap_or(&0) as u64))
+                .unwrap(),
             limit_in_bytes: self
                 .open_path("memory.swap.max", false)
                 .and_then(read_i64_from)
@@ -735,11 +738,10 @@ impl MemController {
         if self.v2 {
             file = "memory.max";
         }
-        self.open_path(file, true)
-            .and_then(|mut file| {
-                file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        self.open_path(file, true).and_then(|mut file| {
+            file.write_all(limit.to_string().as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     /// Set the kernel memory limit of the control group, in bytes.
@@ -757,11 +759,10 @@ impl MemController {
         if self.v2 {
             file = "memory.swap.max";
         }
-        self.open_path(file, true)
-            .and_then(|mut file| {
-                file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        self.open_path(file, true).and_then(|mut file| {
+            file.write_all(limit.to_string().as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     /// Set how much kernel memory can be used for TCP-related buffers by the control group.
@@ -782,11 +783,10 @@ impl MemController {
         if self.v2 {
             file = "memory.low"
         }
-        self.open_path(file, true)
-            .and_then(|mut file| {
-                file.write_all(limit.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        self.open_path(file, true).and_then(|mut file| {
+            file.write_all(limit.to_string().as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     /// Set how likely the kernel is to swap out parts of the address space used by the control
@@ -809,10 +809,10 @@ impl MemController {
             })
     }
 
-    pub fn register_oom_event(&self, key: &str) -> Result<Receiver<String>>{
-        if self.v2{
+    pub fn register_oom_event(&self, key: &str) -> Result<Receiver<String>> {
+        if self.v2 {
             events::notify_on_oom_v2(key, self.get_path())
-        }else {
+        } else {
             events::notify_on_oom_v1(key, self.get_path())
         }
     }
@@ -870,10 +870,10 @@ fn read_string_from(mut file: File) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
     use crate::memory::{
         parse_memory_stat, parse_numa_stat, parse_oom_control, MemoryStat, NumaStat, OomControl,
     };
+    use std::collections::HashMap;
 
     static GOOD_VALUE: &str = "\
 total=51189 N0=51189 N1=123

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -11,12 +11,11 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `net_cls` subsystem of a Cgroup.
@@ -81,7 +80,10 @@ impl<'a> From<&'a Subsystem> for &'a NetClsController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -102,7 +104,8 @@ impl NetClsController {
         self.open_path("net_cls.classid", true)
             .and_then(|mut file| {
                 let s = format!("{:#08X}", class);
-                file.write_all(s.as_ref()).map_err(|e| Error::with_cause(WriteFailed, e))
+                file.write_all(s.as_ref())
+                    .map_err(|e| Error::with_cause(WriteFailed, e))
             })
     }
 

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -12,12 +12,11 @@ use std::fs::File;
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `net_prio` subsystem of a Cgroup.
@@ -82,7 +81,10 @@ impl<'a> From<&'a Subsystem> for &'a NetPrioController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -10,7 +10,7 @@ use crate::error::*;
 use crate::error::ErrorKind::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, MaxValue, max_value_to_string, parse_max_value, PidResources, Resources, Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, MaxValue, parse_max_value, PidResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `pids` subsystem of a Cgroup.
@@ -150,7 +150,7 @@ impl PidController {
     /// extra processes to a control group disregards the limit.
     pub fn set_pid_max(&self, max_pid: MaxValue) -> Result<()> {
         self.open_path("pids.max", true).and_then(|mut file| {
-            let string_to_write = max_value_to_string(max_pid);
+            let string_to_write = max_pid.to_string();
             match file.write_all(string_to_write.as_ref()) {
                 Ok(_) => Ok(()),
                 Err(e) => Err(Error::with_cause(WriteFailed, e)),

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -10,7 +10,7 @@ use crate::error::*;
 use crate::error::ErrorKind::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, PidResources, Resources, Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, MaxValue, max_value_to_string, parse_max_value, PidResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `pids` subsystem of a Cgroup.
@@ -18,22 +18,7 @@ use crate::{
 pub struct PidController {
     base: PathBuf,
     path: PathBuf,
-}
-
-/// The values found in the `pids.max` file in a Cgroup's `pids` subsystem.
-#[derive(Eq, PartialEq, Copy, Clone, Debug)]
-pub enum PidMax {
-    /// This value is returned when the text found `pids.max` is `"max"`.
-    Max,
-    /// When the value in `pids.max` is a numerical value, they are returned via this enum field.
-    Value(i64),
-}
-
-impl Default for PidMax {
-    /// By default, (as per the kernel) `pids.max` should contain `"max"`.
-    fn default() -> Self {
-        PidMax::Max
-    }
+    v2:   bool,
 }
 
 impl ControllerInternal for PidController {
@@ -48,6 +33,10 @@ impl ControllerInternal for PidController {
     }
     fn get_base(&self) -> &PathBuf {
         &self.base
+    }
+
+    fn is_v2(&self) -> bool {
+        self.v2
     }
 
     fn apply(&self, res: &Resources) -> Result<()> {
@@ -107,12 +96,15 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 impl PidController {
     /// Constructors a new `PidController` instance, with `oroot` serving as the controller's root
     /// directory.
-    pub fn new(oroot: PathBuf) -> Self {
+    pub fn new(oroot: PathBuf, v2: bool) -> Self {
         let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+        if !v2 {
+            root.push(Self::controller_type().to_string());
+        }
         Self {
             base: root.clone(),
             path: root,
+            v2:   v2,
         }
     }
 
@@ -140,19 +132,12 @@ impl PidController {
     }
 
     /// The maximum number of processes that can exist at one time in the control group.
-    pub fn get_pid_max(&self) -> Result<PidMax> {
+    pub fn get_pid_max(&self) -> Result<MaxValue> {
         self.open_path("pids.max", false).and_then(|mut file| {
             let mut string = String::new();
             let res = file.read_to_string(&mut string);
             match res {
-                Ok(_) => if string.trim() == "max" {
-                    Ok(PidMax::Max)
-                } else {
-                    match string.trim().parse() {
-                        Ok(val) => Ok(PidMax::Value(val)),
-                        Err(e) => Err(Error::with_cause(ParseError, e)),
-                    }
-                },
+                Ok(_) => parse_max_value(&string),
                 Err(e) => Err(Error::with_cause(ReadFailed, e)),
             }
         })
@@ -163,12 +148,9 @@ impl PidController {
     /// Note that if `get_pid_current()` returns a higher number than what you
     /// are about to set (`max_pid`), then no processess will be killed. Additonally, attaching
     /// extra processes to a control group disregards the limit.
-    pub fn set_pid_max(&self, max_pid: PidMax) -> Result<()> {
+    pub fn set_pid_max(&self, max_pid: MaxValue) -> Result<()> {
         self.open_path("pids.max", true).and_then(|mut file| {
-            let string_to_write = match max_pid {
-                PidMax::Max => "max".to_string(),
-                PidMax::Value(num) => num.to_string(),
-            };
+            let string_to_write = max_value_to_string(max_pid);
             match file.write_all(string_to_write.as_ref()) {
                 Ok(_) => Ok(()),
                 Err(e) => Err(Error::with_cause(WriteFailed, e)),

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -12,11 +12,12 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, MaxValue, parse_max_value, PidResources, Resources, Subsystem,
+    parse_max_value, ControllIdentifier, ControllerInternal, Controllers, MaxValue, PidResources,
+    Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `pids` subsystem of a Cgroup.
@@ -24,7 +25,7 @@ use crate::{
 pub struct PidController {
     base: PathBuf,
     path: PathBuf,
-    v2:   bool,
+    v2: bool,
 }
 
 impl ControllerInternal for PidController {
@@ -94,7 +95,10 @@ impl<'a> From<&'a Subsystem> for &'a PidController {
 fn read_u64_from(mut file: File) -> Result<u64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
-        Ok(_) => string.trim().parse().map_err(|e| Error::with_cause(ParseError, e)),
+        Ok(_) => string
+            .trim()
+            .parse()
+            .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
@@ -110,7 +114,7 @@ impl PidController {
         Self {
             base: root.clone(),
             path: root,
-            v2:   v2,
+            v2: v2,
         }
     }
 

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -11,8 +11,8 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,0 +1,72 @@
+//! This module contains the implementation of the `systemd` cgroup subsystem.
+//!
+use std::path::PathBuf;
+
+use crate::error::*;
+use crate::error::ErrorKind::*;
+
+use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
+
+/// A controller that allows controlling the `systemd` subsystem of a Cgroup.
+///
+#[derive(Debug, Clone)]
+pub struct SystemdController {
+    base: PathBuf,
+    path: PathBuf,
+    v2:   bool,
+}
+
+impl ControllerInternal for SystemdController {
+    fn control_type(&self) -> Controllers {
+        Controllers::Systemd
+    }
+    fn get_path(&self) -> &PathBuf {
+        &self.path
+    }
+    fn get_path_mut(&mut self) -> &mut PathBuf {
+        &mut self.path
+    }
+    fn get_base(&self) -> &PathBuf {
+        &self.base
+    }
+
+    fn apply(&self, _res: &Resources) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl ControllIdentifier for SystemdController {
+    fn controller_type() -> Controllers {
+        Controllers::Systemd
+    }
+}
+
+impl<'a> From<&'a Subsystem> for &'a SystemdController {
+    fn from(sub: &'a Subsystem) -> &'a SystemdController {
+        unsafe {
+            match sub {
+                Subsystem::Systemd(c) => c,
+                _ => {
+                    assert_eq!(1, 0);
+                    ::std::mem::uninitialized()
+                }
+            }
+        }
+    }
+}
+
+impl SystemdController {
+    /// Constructs a new `SystemdController` with `oroot` serving as the root of the control group.
+    pub fn new(oroot: PathBuf, v2: bool) -> Self {
+        let mut root = oroot;
+        if !v2{
+            root.push(Self::controller_type().to_string());
+        }
+        Self {
+            base: root.clone(),
+            path: root,
+            v2:   v2,
+        }
+    }
+
+}

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2020 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! This module contains the implementation of the `systemd` cgroup subsystem.
 //!
 use std::path::PathBuf;

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -7,8 +7,8 @@
 //!
 use std::path::PathBuf;
 
-use crate::error::*;
 use crate::error::ErrorKind::*;
+use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
@@ -18,7 +18,7 @@ use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subs
 pub struct SystemdController {
     base: PathBuf,
     path: PathBuf,
-    v2:   bool,
+    v2: bool,
 }
 
 impl ControllerInternal for SystemdController {
@@ -64,14 +64,13 @@ impl SystemdController {
     /// Constructs a new `SystemdController` with `oroot` serving as the root of the control group.
     pub fn new(oroot: PathBuf, v2: bool) -> Self {
         let mut root = oroot;
-        if !v2{
+        if !v2 {
             root.push(Self::controller_type().to_string());
         }
         Self {
             base: root.clone(),
             path: root,
-            v2:   v2,
+            v2: v2,
         }
     }
-
 }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -11,8 +11,9 @@ use cgroups::cgroup_builder::*;
 
 #[test]
 pub fn test_cpu_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build", h)
         .cpu()
             .shares(85)
             .done()
@@ -29,8 +30,9 @@ pub fn test_cpu_res_build() {
 
 #[test]
 pub fn test_memory_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_memory_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_memory_res_build", h)
         .memory()
             .kernel_memory_limit(128 * 1024 * 1024)
             .swappiness(70)
@@ -50,17 +52,18 @@ pub fn test_memory_res_build() {
 
 #[test]
 pub fn test_pid_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_pid_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_pid_res_build", h)
         .pid()
-            .maximum_number_of_processes(PidMax::Value(123))
+            .maximum_number_of_processes(MaxValue::Value(123))
             .done()
         .build();
 
     {
         let c: &PidController = cg.controller_of().unwrap();
         assert!(c.get_pid_max().is_ok());
-        assert_eq!(c.get_pid_max().unwrap(), PidMax::Value(123));
+        assert_eq!(c.get_pid_max().unwrap(), MaxValue::Value(123));
     }
 
     cg.delete();
@@ -69,8 +72,9 @@ pub fn test_pid_res_build() {
 #[test]
 #[ignore] // ignore this test for now, not sure why my kernel doesn't like it
 pub fn test_devices_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_devices_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_devices_res_build", h)
         .devices()
             .device(1, 6, DeviceType::Char, true,
                     vec![DevicePermissions::Read])
@@ -95,8 +99,13 @@ pub fn test_devices_res_build() {
 
 #[test]
 pub fn test_network_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_network_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    if h.v2() {
+        // FIXME
+        return
+    }
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_network_res_build", h)
         .network()
             .class_id(1337)
             .done()
@@ -112,8 +121,13 @@ pub fn test_network_res_build() {
 
 #[test]
 pub fn test_hugepages_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    if h.v2() {
+        // FIXME
+        return
+    }
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build", h)
         .hugepages()
             .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
             .done()
@@ -129,8 +143,9 @@ pub fn test_hugepages_res_build() {
 
 #[test]
 pub fn test_blkio_res_build() {
-    let v1 = crate::hierarchies::V1::new();
-    let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", &v1)
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", h)
         .blkio()
             .weight(100)
             .done()

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -42,8 +42,10 @@ pub fn test_memory_res_build() {
 
     {
         let c: &MemController = cg.controller_of().unwrap();
-        assert_eq!(c.kmem_stat().limit_in_bytes, 128 * 1024 * 1024);
-        assert_eq!(c.memory_stat().swappiness, 70);
+        if !c.v2() {
+            assert_eq!(c.kmem_stat().limit_in_bytes, 128 * 1024 * 1024);
+            assert_eq!(c.memory_stat().swappiness, 70);
+        }
         assert_eq!(c.memory_stat().limit_in_bytes, 1024 * 1024 * 1024);
     }
 
@@ -101,7 +103,7 @@ pub fn test_devices_res_build() {
 pub fn test_network_res_build() {
     let h = cgroups::hierarchies::auto();
     if h.v2() {
-        // FIXME
+        // FIXME add cases for v2
         return
     }
     let h = Box::new(&*h);
@@ -123,7 +125,7 @@ pub fn test_network_res_build() {
 pub fn test_hugepages_res_build() {
     let h = cgroups::hierarchies::auto();
     if h.v2() {
-        // FIXME
+        // FIXME add cases for v2
         return
     }
     let h = Box::new(&*h);
@@ -142,12 +144,13 @@ pub fn test_hugepages_res_build() {
 }
 
 #[test]
+#[ignore] // high version kernel not support `blkio.weight`
 pub fn test_blkio_res_build() {
     let h = cgroups::hierarchies::auto();
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", h)
         .blkio()
-            .weight(100)
+            .weight(Some(100))
             .done()
         .build();
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -5,15 +5,15 @@
 //
 
 //! Some simple tests covering the builder pattern for control groups.
-use cgroups::*;
-use cgroups::cpu::*;
-use cgroups::devices::*;
-use cgroups::pid::*;
-use cgroups::memory::*;
-use cgroups::net_cls::*;
-use cgroups::hugetlb::*;
 use cgroups::blkio::*;
 use cgroups::cgroup_builder::*;
+use cgroups::cpu::*;
+use cgroups::devices::*;
+use cgroups::hugetlb::*;
+use cgroups::memory::*;
+use cgroups::net_cls::*;
+use cgroups::pid::*;
+use cgroups::*;
 
 #[test]
 pub fn test_cpu_res_build() {
@@ -21,8 +21,8 @@ pub fn test_cpu_res_build() {
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build", h)
         .cpu()
-            .shares(85)
-            .done()
+        .shares(85)
+        .done()
         .build();
 
     {
@@ -40,10 +40,10 @@ pub fn test_memory_res_build() {
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_memory_res_build", h)
         .memory()
-            .kernel_memory_limit(128 * 1024 * 1024)
-            .swappiness(70)
-            .memory_hard_limit(1024 * 1024 * 1024)
-            .done()
+        .kernel_memory_limit(128 * 1024 * 1024)
+        .swappiness(70)
+        .memory_hard_limit(1024 * 1024 * 1024)
+        .done()
         .build();
 
     {
@@ -64,8 +64,8 @@ pub fn test_pid_res_build() {
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_pid_res_build", h)
         .pid()
-            .maximum_number_of_processes(MaxValue::Value(123))
-            .done()
+        .maximum_number_of_processes(MaxValue::Value(123))
+        .done()
         .build();
 
     {
@@ -84,23 +84,23 @@ pub fn test_devices_res_build() {
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_devices_res_build", h)
         .devices()
-            .device(1, 6, DeviceType::Char, true,
-                    vec![DevicePermissions::Read])
-            .done()
+        .device(1, 6, DeviceType::Char, true, vec![DevicePermissions::Read])
+        .done()
         .build();
 
     {
         let c: &DevicesController = cg.controller_of().unwrap();
         assert!(c.allowed_devices().is_ok());
-        assert_eq!(c.allowed_devices().unwrap(), vec![
-                   DeviceResource {
-                       allow: true,
-                       devtype: DeviceType::Char,
-                       major: 1,
-                       minor: 6,
-                       access: vec![DevicePermissions::Read],
-                   }
-        ]);
+        assert_eq!(
+            c.allowed_devices().unwrap(),
+            vec![DeviceResource {
+                allow: true,
+                devtype: DeviceType::Char,
+                major: 1,
+                minor: 6,
+                access: vec![DevicePermissions::Read],
+            }]
+        );
     }
     cg.delete();
 }
@@ -110,13 +110,13 @@ pub fn test_network_res_build() {
     let h = cgroups::hierarchies::auto();
     if h.v2() {
         // FIXME add cases for v2
-        return
+        return;
     }
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_network_res_build", h)
         .network()
-            .class_id(1337)
-            .done()
+        .class_id(1337)
+        .done()
         .build();
 
     {
@@ -132,19 +132,22 @@ pub fn test_hugepages_res_build() {
     let h = cgroups::hierarchies::auto();
     if h.v2() {
         // FIXME add cases for v2
-        return
+        return;
     }
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build", h)
         .hugepages()
-            .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
-            .done()
+        .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
+        .done()
         .build();
 
     {
         let c: &HugeTlbController = cg.controller_of().unwrap();
         assert!(c.limit_in_bytes(&"2MB".to_string()).is_ok());
-        assert_eq!(c.limit_in_bytes(&"2MB".to_string()).unwrap(), 4 * 2 * 1024 * 1024);
+        assert_eq!(
+            c.limit_in_bytes(&"2MB".to_string()).unwrap(),
+            4 * 2 * 1024 * 1024
+        );
     }
     cg.delete();
 }
@@ -156,8 +159,8 @@ pub fn test_blkio_res_build() {
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", h)
         .blkio()
-            .weight(Some(100))
-            .done()
+        .weight(Some(100))
+        .done()
         .build();
 
     {

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -5,9 +5,9 @@
 //
 
 //! Simple unit tests about the control groups system.
-use cgroups::{Cgroup, CgroupPid, Hierarchy, Subsystem};
 use cgroups::memory::{MemController, SetMemory};
 use cgroups::Controller;
+use cgroups::{Cgroup, CgroupPid, Hierarchy, Subsystem};
 use std::collections::HashMap;
 
 #[test]
@@ -38,11 +38,10 @@ fn test_tasks_iterator() {
     cg.delete();
 }
 
-
 #[test]
 fn test_cgroup_with_relative_paths() {
     if cgroups::hierarchies::is_cgroup2_unified_mode() {
-        return
+        return;
     }
     let h = cgroups::hierarchies::auto();
     let cgroup_root = h.root();
@@ -60,14 +59,30 @@ fn test_cgroup_with_relative_paths() {
                 let cgroup_path = c.path().to_str().unwrap();
                 let relative_path = "/pids/";
                 // cgroup_path = cgroup_root + relative_path + cgroup_name
-                assert_eq!(cgroup_path, format!("{}{}{}", cgroup_root.to_str().unwrap(), relative_path, cgroup_name));
-            },
+                assert_eq!(
+                    cgroup_path,
+                    format!(
+                        "{}{}{}",
+                        cgroup_root.to_str().unwrap(),
+                        relative_path,
+                        cgroup_name
+                    )
+                );
+            }
             Subsystem::Mem(c) => {
                 let cgroup_path = c.path().to_str().unwrap();
                 // cgroup_path = cgroup_root + relative_path + cgroup_name
-                assert_eq!(cgroup_path, format!("{}/memory{}/{}", cgroup_root.to_str().unwrap(), mem_relative_path, cgroup_name));
-            },
-            _ => {}, 
+                assert_eq!(
+                    cgroup_path,
+                    format!(
+                        "{}/memory{}/{}",
+                        cgroup_root.to_str().unwrap(),
+                        mem_relative_path,
+                        cgroup_name
+                    )
+                );
+            }
+            _ => {}
         });
     }
     cg.delete();
@@ -76,14 +91,14 @@ fn test_cgroup_with_relative_paths() {
 #[test]
 fn test_cgroup_v2() {
     if !cgroups::hierarchies::is_cgroup2_unified_mode() {
-        return
+        return;
     }
     let h = cgroups::hierarchies::auto();
     let h = Box::new(&*h);
     let cg = Cgroup::new_with_relative_paths(h, String::from("test_v2"), HashMap::new());
 
     let mem_controller: &MemController = cg.controller_of().unwrap();
-    let (mem, swp, rev) = (4 * 1024 * 1000, 2 * 1024* 1000, 1024 * 1000);
+    let (mem, swp, rev) = (4 * 1024 * 1000, 2 * 1024 * 1000, 1024 * 1000);
 
     let _ = mem_controller.set_limit(mem);
     let _ = mem_controller.set_memswap_limit(swp);

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -1,5 +1,7 @@
 //! Simple unit tests about the control groups system.
-use cgroups::{Cgroup, CgroupPid, Hierarchy};
+use cgroups::{Cgroup, CgroupPid, Hierarchy, Subsystem};
+use cgroups::memory::{MemController, SetMemory};
+use std::collections::HashMap;
 
 #[test]
 fn test_tasks_iterator() {
@@ -21,6 +23,27 @@ fn test_tasks_iterator() {
 
         // Verify that it was indeed removed.
         assert_eq!(tasks.next(), None);
+    }
+    cg.delete();
+}
+
+
+#[test]
+fn test_cgroup_with_prefix() {
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let mut prefixes = HashMap::new();
+    prefixes.insert("memory".to_string(), "/memory/abc/def".to_string());
+    let cg = Cgroup::new_with_prefix(h, String::from("test_cgroup_with_prefix"), prefixes);
+    {
+        let subsystems = cg.subsystems();
+        println!("mem path: {:?}", &subsystems);
+        subsystems.into_iter().for_each(|sub| match sub {
+            Subsystem::Pid(c) => {println!("path {:?}", c);},
+            // base: "/sys/fs/cgroup", path: "/sys/fs/cgroup/memory/abc/def/test_cgroup_with_prefix"
+            Subsystem::Mem(c) => {println!("path {:?}", c);},
+            _ => {}, 
+        });
     }
     cg.delete();
 }

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -1,6 +1,7 @@
 //! Simple unit tests about the control groups system.
 use cgroups::{Cgroup, CgroupPid, Hierarchy, Subsystem};
 use cgroups::memory::{MemController, SetMemory};
+use cgroups::Controller;
 use std::collections::HashMap;
 
 #[test]
@@ -11,7 +12,11 @@ fn test_tasks_iterator() {
     let cg = Cgroup::new(h, String::from("test_tasks_iterator"));
     {
         // Add a task to the control group.
-        cg.add_task(CgroupPid::from(pid));
+        cg.add_task(CgroupPid::from(pid)).unwrap();
+
+        use std::{thread, time};
+        thread::sleep(time::Duration::from_millis(100));
+
         let mut tasks = cg.tasks().into_iter();
         // Verify that the task is indeed in the control group
         assert_eq!(tasks.next(), Some(CgroupPid::from(pid)));
@@ -29,21 +34,58 @@ fn test_tasks_iterator() {
 
 
 #[test]
-fn test_cgroup_with_prefix() {
+fn test_cgroup_with_relative_paths() {
+    if cgroups::hierarchies::is_cgroup2_unified_mode() {
+        return
+    }
     let h = cgroups::hierarchies::auto();
     let h = Box::new(&*h);
-    let mut prefixes = HashMap::new();
-    prefixes.insert("memory".to_string(), "/memory/abc/def".to_string());
-    let cg = Cgroup::new_with_prefix(h, String::from("test_cgroup_with_prefix"), prefixes);
+    let mut relative_paths = HashMap::new();
+    relative_paths.insert("memory".to_string(), "/mmm/abc/def".to_string());
+    let cg = Cgroup::new_with_relative_paths(h, String::from("test_cgroup_with_prefix"), relative_paths);
     {
         let subsystems = cg.subsystems();
-        println!("mem path: {:?}", &subsystems);
         subsystems.into_iter().for_each(|sub| match sub {
-            Subsystem::Pid(c) => {println!("path {:?}", c);},
-            // base: "/sys/fs/cgroup", path: "/sys/fs/cgroup/memory/abc/def/test_cgroup_with_prefix"
-            Subsystem::Mem(c) => {println!("path {:?}", c);},
+            Subsystem::Pid(c) => {
+                let p = c.path().to_str().unwrap();
+                let rel_path = p.trim_start_matches("/sys/fs/cgroup/pids");
+                assert_eq!(rel_path, "/test_cgroup_with_prefix")
+            },
+            Subsystem::Mem(c) => {
+                let p = c.path().to_str().unwrap();
+                let rel_path = p.trim_start_matches("/sys/fs/cgroup/memory");
+                assert_eq!(rel_path, "/mmm/abc/def/test_cgroup_with_prefix")
+            },
             _ => {}, 
         });
     }
+    cg.delete();
+}
+
+#[test]
+fn test_cgroup_v2() {
+    if !cgroups::hierarchies::is_cgroup2_unified_mode() {
+        return
+    }
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new_with_relative_paths(h, String::from("test_v2"), HashMap::new());
+
+    let mem_controller: &MemController = cg.controller_of().unwrap();
+    let (mem, swp, rev) = (4 * 1024 * 1000, 2 * 1024* 1000, 1024 * 1000);
+
+    let _ = mem_controller.set_limit(mem);
+    let _ = mem_controller.set_memswap_limit(swp);
+    let _ = mem_controller.set_soft_limit(rev);
+
+    let memory_stat = mem_controller.memory_stat();
+    println!("memory_stat {:?}", memory_stat);
+    assert_eq!(mem, memory_stat.limit_in_bytes);
+    assert_eq!(rev, memory_stat.soft_limit_in_bytes);
+
+    let memswap = mem_controller.memswap();
+    println!("memswap {:?}", memswap);
+    assert_eq!(swp, memswap.limit_in_bytes);
+
     cg.delete();
 }

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -1,11 +1,12 @@
 //! Simple unit tests about the control groups system.
-use cgroups::{Cgroup, CgroupPid};
+use cgroups::{Cgroup, CgroupPid, Hierarchy};
 
 #[test]
 fn test_tasks_iterator() {
-    let hier = cgroups::hierarchies::V1::new();
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
     let pid = libc::pid_t::from(nix::unistd::getpid()) as u64;
-    let cg = Cgroup::new(&hier, String::from("test_tasks_iterator"));
+    let cg = Cgroup::new(h, String::from("test_tasks_iterator"));
     {
         // Add a task to the control group.
         cg.add_task(CgroupPid::from(pid));

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -25,7 +25,6 @@ fn test_cpuset_memory_pressure_root_cg() {
     cg.delete();
 }
 
-
 #[test]
 fn test_cpuset_set_cpus() {
     let h = cgroups::hierarchies::auto();
@@ -48,10 +47,11 @@ fn test_cpuset_set_cpus() {
 
         let set = cpuset.cpuset();
         assert_eq!(1, set.cpus.len());
-        assert_eq!((0,0), set.cpus[0]);
+        assert_eq!((0, 0), set.cpus[0]);
 
         // all cpus in system
-        let cpus = fs::read_to_string("/sys/fs/cgroup/cpuset.cpus.effective").unwrap_or("".to_string());
+        let cpus =
+            fs::read_to_string("/sys/fs/cgroup/cpuset.cpus.effective").unwrap_or("".to_string());
         let cpus = cpus.trim();
         if cpus != "" {
             let r = cpuset.set_cpus(&cpus);

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -1,17 +1,54 @@
 use cgroups::cpuset::CpuSetController;
 use cgroups::error::ErrorKind;
-use cgroups::Cgroup;
+use cgroups::{Cgroup, CpuResources, Hierarchy, Resources};
 
 #[test]
 fn test_cpuset_memory_pressure_root_cg() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_cpuset_memory_pressure_root_cg"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_cpuset_memory_pressure_root_cg"));
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
         // This is not a root control group, so it should fail via InvalidOperation.
         let res = cpuset.set_enable_memory_pressure(true);
         assert_eq!(res.unwrap_err().kind(), &ErrorKind::InvalidOperation);
+    }
+    cg.delete();
+}
+
+
+#[test]
+fn test_cpuset_set_cpus() {
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus"));
+    {
+        let cpuset: &CpuSetController = cg.controller_of().unwrap();
+
+        let set = cpuset.cpuset();
+        assert_eq!(0, set.cpus.len());
+
+        // 0
+        let r = cpuset.set_cpus("0");
+        assert_eq!(true, r.is_ok());
+
+        let set = cpuset.cpuset();
+        assert_eq!(1, set.cpus.len());
+        assert_eq!((0,0), set.cpus[0]);
+
+
+        // 0-1
+        // FIXME need two cores
+        let r = cpuset.set_cpus("0-1");
+        assert_eq!(true, r.is_ok());
+
+        let set = cpuset.cpuset();
+        assert_eq!(1, set.cpus.len());
+        assert_eq!((0,1), set.cpus[0]);
+
+
+
     }
     cg.delete();
 }

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -1,12 +1,13 @@
 //! Integration tests about the devices subsystem
 
 use cgroups::devices::{DevicePermissions, DeviceType, DevicesController};
-use cgroups::{Cgroup, DeviceResource};
+use cgroups::{Cgroup, DeviceResource, Hierarchy};
 
 #[test]
 fn test_devices_parsing() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_devices_parsing"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_devices_parsing"));
     {
         let devices: &DevicesController = cg.controller_of().unwrap();
 

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -13,7 +13,7 @@ use cgroups::{Cgroup, DeviceResource, Hierarchy};
 fn test_devices_parsing() {
     // now only v2
     if cgroups::hierarchies::is_cgroup2_unified_mode() {
-        return
+        return;
     }
 
     let h = cgroups::hierarchies::auto();

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -5,6 +5,11 @@ use cgroups::{Cgroup, DeviceResource, Hierarchy};
 
 #[test]
 fn test_devices_parsing() {
+    // no only v2
+    if cgroups::hierarchies::is_cgroup2_unified_mode() {
+        return
+    }
+
     let h = cgroups::hierarchies::auto();
     let h = Box::new(&*h);
     let cg = Cgroup::new(h, String::from("test_devices_parsing"));

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -5,7 +5,7 @@ use cgroups::{Cgroup, DeviceResource, Hierarchy};
 
 #[test]
 fn test_devices_parsing() {
-    // no only v2
+    // now only v2
     if cgroups::hierarchies::is_cgroup2_unified_mode() {
         return
     }

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -8,7 +8,7 @@ use cgroups::error::*;
 
 #[test]
 fn test_hugetlb_sizes() {
-    // no only v2
+    // now only v2
     if cgroups::hierarchies::is_cgroup2_unified_mode() {
         return
     }

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -1,6 +1,6 @@
 //! Integration tests about the hugetlb subsystem
 use cgroups::hugetlb::HugeTlbController;
-use cgroups::Cgroup;
+use cgroups::{Cgroup, Hierarchy};
 use cgroups::Controller;
 
 use cgroups::error::ErrorKind::*;
@@ -8,8 +8,9 @@ use cgroups::error::*;
 
 #[test]
 fn test_hugetlb_sizes() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_hugetlb_sizes"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_hugetlb_sizes"));
     {
         let hugetlb_controller: &HugeTlbController = cg.controller_of().unwrap();
         let sizes = hugetlb_controller.get_sizes();

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2020 And Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Integration tests about the hugetlb subsystem
 use cgroups::hugetlb::HugeTlbController;
 use cgroups::{Cgroup, Hierarchy};

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -5,8 +5,8 @@
 
 //! Integration tests about the hugetlb subsystem
 use cgroups::hugetlb::HugeTlbController;
-use cgroups::{Cgroup, Hierarchy};
 use cgroups::Controller;
+use cgroups::{Cgroup, Hierarchy};
 
 use cgroups::error::ErrorKind::*;
 use cgroups::error::*;
@@ -15,7 +15,7 @@ use cgroups::error::*;
 fn test_hugetlb_sizes() {
     // now only v2
     if cgroups::hierarchies::is_cgroup2_unified_mode() {
-        return
+        return;
     }
 
     let h = cgroups::hierarchies::auto();

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -8,6 +8,11 @@ use cgroups::error::*;
 
 #[test]
 fn test_hugetlb_sizes() {
+    // no only v2
+    if cgroups::hierarchies::is_cgroup2_unified_mode() {
+        return
+    }
+
     let h = cgroups::hierarchies::auto();
     let h = Box::new(&*h);
     let cg = Cgroup::new(h, String::from("test_hugetlb_sizes"));

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -1,10 +1,10 @@
 //! Integration tests about the hugetlb subsystem
-use cgroups::hugetlb::{HugeTlbController};
-use cgroups::Controller;
+use cgroups::hugetlb::HugeTlbController;
 use cgroups::Cgroup;
+use cgroups::Controller;
 
-use cgroups::error::*;
 use cgroups::error::ErrorKind::*;
+use cgroups::error::*;
 
 #[test]
 fn test_hugetlb_sizes() {
@@ -20,15 +20,14 @@ fn test_hugetlb_sizes() {
         let supported = hugetlb_controller.size_supported(size);
         assert_eq!(supported, true);
 
-        assert_no_error( hugetlb_controller.failcnt(size));
-        assert_no_error( hugetlb_controller.limit_in_bytes(size));
-        assert_no_error( hugetlb_controller.usage_in_bytes(size));
-        assert_no_error( hugetlb_controller.max_usage_in_bytes(size));
+        assert_no_error(hugetlb_controller.failcnt(size));
+        assert_no_error(hugetlb_controller.limit_in_bytes(size));
+        assert_no_error(hugetlb_controller.usage_in_bytes(size));
+        assert_no_error(hugetlb_controller.max_usage_in_bytes(size));
     }
     cg.delete();
 }
 
-
-fn assert_no_error(r: Result<u64> ) {
-    assert_eq!(!r.is_err() , true)
+fn assert_no_error(r: Result<u64>) {
+    assert_eq!(!r.is_err(), true)
 }

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -1,0 +1,34 @@
+//! Integration tests about the hugetlb subsystem
+use cgroups::hugetlb::{HugeTlbController};
+use cgroups::Controller;
+use cgroups::Cgroup;
+
+use cgroups::error::*;
+use cgroups::error::ErrorKind::*;
+
+#[test]
+fn test_hugetlb_sizes() {
+    let hier = cgroups::hierarchies::V1::new();
+    let cg = Cgroup::new(&hier, String::from("test_hugetlb_sizes"));
+    {
+        let hugetlb_controller: &HugeTlbController = cg.controller_of().unwrap();
+        let sizes = hugetlb_controller.get_sizes();
+
+        let size = "2MB";
+        assert_eq!(sizes, vec![size.to_string()]);
+
+        let supported = hugetlb_controller.size_supported(size);
+        assert_eq!(supported, true);
+
+        assert_no_error( hugetlb_controller.failcnt(size));
+        assert_no_error( hugetlb_controller.limit_in_bytes(size));
+        assert_no_error( hugetlb_controller.usage_in_bytes(size));
+        assert_no_error( hugetlb_controller.max_usage_in_bytes(size));
+    }
+    cg.delete();
+}
+
+
+fn assert_no_error(r: Result<u64> ) {
+    assert_eq!(!r.is_err() , true)
+}

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -6,10 +6,7 @@
 //! Integration tests about the hugetlb subsystem
 use cgroups::memory::{MemController, SetMemory};
 use cgroups::Controller;
-use cgroups::{Cgroup, Hierarchy, MaxValue};
-
-use cgroups::error::ErrorKind::*;
-use cgroups::error::*;
+use cgroups::{Cgroup, MaxValue};
 
 #[test]
 fn test_disable_oom_killer() {
@@ -23,7 +20,7 @@ fn test_disable_oom_killer() {
         let m = mem_controller.memory_stat();
         assert_eq!(m.oom_control.oom_kill_disable, false);
 
-        // FIXME only v1
+        // now only v1
         if !mem_controller.v2() {
             // disable oom killer
             let r = mem_controller.disable_oom_killer();

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -5,8 +5,8 @@
 
 //! Integration tests about the hugetlb subsystem
 use cgroups::memory::{MemController, SetMemory};
-use cgroups::{Cgroup, Hierarchy, MaxValue};
 use cgroups::Controller;
+use cgroups::{Cgroup, Hierarchy, MaxValue};
 
 use cgroups::error::ErrorKind::*;
 use cgroups::error::*;
@@ -24,7 +24,7 @@ fn test_disable_oom_killer() {
         assert_eq!(m.oom_control.oom_kill_disable, false);
 
         // FIXME only v1
-        if !mem_controller.v2(){
+        if !mem_controller.v2() {
             // disable oom killer
             let r = mem_controller.disable_oom_killer();
             assert_eq!(r.is_err(), false);
@@ -33,7 +33,6 @@ fn test_disable_oom_killer() {
             let m = mem_controller.memory_stat();
             assert_eq!(m.oom_control.oom_kill_disable, true);
         }
-
     }
     cg.delete();
 }
@@ -42,7 +41,7 @@ fn test_disable_oom_killer() {
 fn set_mem_v2() {
     let h = cgroups::hierarchies::auto();
     if !h.v2() {
-        return
+        return;
     }
 
     let h = Box::new(&*h);
@@ -59,10 +58,10 @@ fn set_mem_v2() {
         assert_eq!(m.max, Some(MaxValue::Max));
 
         // case 2: set parts
-        let m = SetMemory{
-            low: Some(MaxValue::Value(1024*1024* 2)),
-            high: Some(MaxValue::Value(1024*1024*1024* 2)),
-            min: Some(MaxValue::Value(1024*1024* 3)),
+        let m = SetMemory {
+            low: Some(MaxValue::Value(1024 * 1024 * 2)),
+            high: Some(MaxValue::Value(1024 * 1024 * 1024 * 2)),
+            min: Some(MaxValue::Value(1024 * 1024 * 3)),
             max: None,
         };
         let r = mem_controller.set_mem(m);
@@ -70,17 +69,15 @@ fn set_mem_v2() {
 
         let m = mem_controller.get_mem().unwrap();
         // get
-        assert_eq!(m.low, Some(MaxValue::Value(1024*1024* 2)));
-        assert_eq!(m.min, Some(MaxValue::Value(1024*1024* 3)));
-        assert_eq!(m.high, Some(MaxValue::Value(1024*1024*1024* 2)));
+        assert_eq!(m.low, Some(MaxValue::Value(1024 * 1024 * 2)));
+        assert_eq!(m.min, Some(MaxValue::Value(1024 * 1024 * 3)));
+        assert_eq!(m.high, Some(MaxValue::Value(1024 * 1024 * 1024 * 2)));
         assert_eq!(m.max, Some(MaxValue::Max));
 
-
-
         // case 3: set parts
-        let m = SetMemory{
-            max: Some(MaxValue::Value(1024*1024*1024* 2)),
-            min: Some(MaxValue::Value(1024*1024* 4)),
+        let m = SetMemory {
+            max: Some(MaxValue::Value(1024 * 1024 * 1024 * 2)),
+            min: Some(MaxValue::Value(1024 * 1024 * 4)),
             high: Some(MaxValue::Max),
             low: None,
         };
@@ -89,9 +86,9 @@ fn set_mem_v2() {
 
         let m = mem_controller.get_mem().unwrap();
         // get
-        assert_eq!(m.low, Some(MaxValue::Value(1024*1024* 2)));
-        assert_eq!(m.min, Some(MaxValue::Value(1024*1024* 4)));
-        assert_eq!(m.max, Some(MaxValue::Value(1024*1024*1024* 2)));
+        assert_eq!(m.low, Some(MaxValue::Value(1024 * 1024 * 2)));
+        assert_eq!(m.min, Some(MaxValue::Value(1024 * 1024 * 4)));
+        assert_eq!(m.max, Some(MaxValue::Value(1024 * 1024 * 1024 * 2)));
         assert_eq!(m.high, Some(MaxValue::Max));
     }
 

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2020 And Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Integration tests about the hugetlb subsystem
 use cgroups::memory::{MemController, SetMemory};
 use cgroups::{Cgroup, Hierarchy, MaxValue};

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,6 +1,6 @@
 //! Integration tests about the hugetlb subsystem
-use cgroups::memory::MemController;
-use cgroups::Cgroup;
+use cgroups::memory::{MemController, SetMemory};
+use cgroups::{Cgroup, Hierarchy, MaxValue};
 use cgroups::Controller;
 
 use cgroups::error::ErrorKind::*;
@@ -8,8 +8,9 @@ use cgroups::error::*;
 
 #[test]
 fn test_disable_oom_killer() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_disable_oom_killer"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_disable_oom_killer"));
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 
@@ -17,13 +18,77 @@ fn test_disable_oom_killer() {
         let m = mem_controller.memory_stat();
         assert_eq!(m.oom_control.oom_kill_disable, false);
 
-        // disable oom killer
-        let r = mem_controller.disable_oom_killer();
-        assert_eq!(r.is_err(), false);
+        // FIXME only v1
+        if !mem_controller.v2(){
+            // disable oom killer
+            let r = mem_controller.disable_oom_killer();
+            assert_eq!(r.is_err(), false);
 
-        // after disable
-        let m = mem_controller.memory_stat();
-        assert_eq!(m.oom_control.oom_kill_disable, true);
+            // after disable
+            let m = mem_controller.memory_stat();
+            assert_eq!(m.oom_control.oom_kill_disable, true);
+        }
+
     }
+    cg.delete();
+}
+
+#[test]
+fn set_mem_v2() {
+    let h = cgroups::hierarchies::auto();
+    if !h.v2() {
+        return
+    }
+
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("set_mem_v2"));
+    {
+        let mem_controller: &MemController = cg.controller_of().unwrap();
+
+        // before disable
+        let m = mem_controller.get_mem().unwrap();
+        // case 1: get default value
+        assert_eq!(m.low, Some(MaxValue::Value(0)));
+        assert_eq!(m.min, Some(MaxValue::Value(0)));
+        assert_eq!(m.high, Some(MaxValue::Max));
+        assert_eq!(m.max, Some(MaxValue::Max));
+
+        // case 2: set parts
+        let m = SetMemory{
+            low: Some(MaxValue::Value(1024*1024* 2)),
+            high: Some(MaxValue::Value(1024*1024*1024* 2)),
+            min: Some(MaxValue::Value(1024*1024* 3)),
+            max: None,
+        };
+        let r = mem_controller.set_mem(m);
+        assert_eq!(true, r.is_ok());
+
+        let m = mem_controller.get_mem().unwrap();
+        // get
+        assert_eq!(m.low, Some(MaxValue::Value(1024*1024* 2)));
+        assert_eq!(m.min, Some(MaxValue::Value(1024*1024* 3)));
+        assert_eq!(m.high, Some(MaxValue::Value(1024*1024*1024* 2)));
+        assert_eq!(m.max, Some(MaxValue::Max));
+
+
+
+        // case 3: set parts
+        let m = SetMemory{
+            max: Some(MaxValue::Value(1024*1024*1024* 2)),
+            min: Some(MaxValue::Value(1024*1024* 4)),
+            high: Some(MaxValue::Max),
+            low: None,
+        };
+        let r = mem_controller.set_mem(m);
+        assert_eq!(true, r.is_ok());
+
+        let m = mem_controller.get_mem().unwrap();
+        // get
+        assert_eq!(m.low, Some(MaxValue::Value(1024*1024* 2)));
+        assert_eq!(m.min, Some(MaxValue::Value(1024*1024* 4)));
+        assert_eq!(m.max, Some(MaxValue::Value(1024*1024*1024* 2)));
+        assert_eq!(m.high, Some(MaxValue::Max));
+    }
+
     cg.delete();
 }

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -1,0 +1,29 @@
+//! Integration tests about the hugetlb subsystem
+use cgroups::memory::MemController;
+use cgroups::Cgroup;
+use cgroups::Controller;
+
+use cgroups::error::ErrorKind::*;
+use cgroups::error::*;
+
+#[test]
+fn test_disable_oom_killer() {
+    let hier = cgroups::hierarchies::V1::new();
+    let cg = Cgroup::new(&hier, String::from("test_disable_oom_killer"));
+    {
+        let mem_controller: &MemController = cg.controller_of().unwrap();
+
+        // before disable
+        let m = mem_controller.memory_stat();
+        assert_eq!(m.oom_control.oom_kill_disable, false);
+
+        // disable oom killer
+        let r = mem_controller.disable_oom_killer();
+        assert_eq!(r.is_err(), false);
+
+        // after disable
+        let m = mem_controller.memory_stat();
+        assert_eq!(m.oom_control.oom_kill_disable, true);
+    }
+    cg.delete();
+}

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -65,13 +65,13 @@ fn test_pid_events_is_not_zero() {
         match fork() {
             Ok(ForkResult::Parent { child, .. }) => {
                 // move the process into the control group
-                pids.add_task(&(pid_t::from(child) as u64).into());
+                let _ = pids.add_task(&(pid_t::from(child) as u64).into());
 
                 println!("added task to cg: {:?}", child);
 
                 // Set limit to one
-                pids.set_pid_max(MaxValue::Value(1));
-                println!("err = {:?}", pids.get_pid_max());
+                let _ = pids.set_pid_max(MaxValue::Value(1));
+                println!("current pid.max = {:?}", pids.get_pid_max());
 
                 // wait on the child
                 let res = waitpid(child, None);

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -1,7 +1,7 @@
 //! Integration tests about the pids subsystem
-use cgroups::pid::{PidController, PidMax};
+use cgroups::pid::{PidController};
 use cgroups::Controller;
-use cgroups::{Cgroup, CgroupPid, PidResources, Resources};
+use cgroups::{Cgroup, CgroupPid, Hierarchy, MaxValue, PidResources, Resources};
 
 use nix::sys::wait::{waitpid, WaitStatus};
 use nix::unistd::{fork, ForkResult, Pid};
@@ -12,22 +12,24 @@ use std::thread;
 
 #[test]
 fn create_and_delete_cgroup() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("create_and_delete_cgroup"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("create_and_delete_cgroup"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
-        pidcontroller.set_pid_max(PidMax::Value(1337));
+        pidcontroller.set_pid_max(MaxValue::Value(1337));
         let max = pidcontroller.get_pid_max();
         assert!(max.is_ok());
-        assert_eq!(max.unwrap(), PidMax::Value(1337));
+        assert_eq!(max.unwrap(), MaxValue::Value(1337));
     }
     cg.delete();
 }
 
 #[test]
 fn test_pids_current_is_zero() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_pids_current_is_zero"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_pids_current_is_zero"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let current = pidcontroller.get_pid_current();
@@ -38,8 +40,9 @@ fn test_pids_current_is_zero() {
 
 #[test]
 fn test_pids_events_is_zero() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_pids_events_is_zero"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_pids_events_is_zero"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let events = pidcontroller.get_pid_events();
@@ -51,8 +54,9 @@ fn test_pids_events_is_zero() {
 
 #[test]
 fn test_pid_events_is_not_zero() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("test_pid_events_is_not_zero"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("test_pid_events_is_not_zero"));
     {
         let pids: &PidController = cg.controller_of().unwrap();
         let before = pids.get_pid_events();
@@ -66,7 +70,7 @@ fn test_pid_events_is_not_zero() {
                 println!("added task to cg: {:?}", child);
 
                 // Set limit to one
-                pids.set_pid_max(PidMax::Value(1));
+                pids.set_pid_max(MaxValue::Value(1));
                 println!("err = {:?}", pids.get_pid_max());
 
                 // wait on the child
@@ -84,7 +88,7 @@ fn test_pid_events_is_not_zero() {
             }
             Ok(ForkResult::Child) => loop {
                 let pids_max = pids.get_pid_max();
-                if pids_max.is_ok() && pids_max.unwrap() == PidMax::Value(1) {
+                if pids_max.is_ok() && pids_max.unwrap() == MaxValue::Value(1) {
                     if let Err(_) = fork() {
                         unsafe { libc::exit(0) };
                     } else {

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -5,7 +5,7 @@
 //
 
 //! Integration tests about the pids subsystem
-use cgroups::pid::{PidController};
+use cgroups::pid::PidController;
 use cgroups::Controller;
 use cgroups::{Cgroup, CgroupPid, Hierarchy, MaxValue, PidResources, Resources};
 

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
 //
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -1,3 +1,9 @@
+// Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 And Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
 //! Integration test about setting resources using `apply()`
 use cgroups::pid::{PidController};
 use cgroups::{Cgroup, Hierarchy, MaxValue, PidResources, Resources};

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -1,16 +1,17 @@
 //! Integration test about setting resources using `apply()`
-use cgroups::pid::{PidController, PidMax};
-use cgroups::{Cgroup, PidResources, Resources};
+use cgroups::pid::{PidController};
+use cgroups::{Cgroup, Hierarchy, MaxValue, PidResources, Resources};
 
 #[test]
 fn pid_resources() {
-    let hier = cgroups::hierarchies::V1::new();
-    let cg = Cgroup::new(&hier, String::from("pid_resources"));
+    let h = cgroups::hierarchies::auto();
+    let h = Box::new(&*h);
+    let cg = Cgroup::new(h, String::from("pid_resources"));
     {
         let res = Resources {
             pid: PidResources {
                 update_values: true,
-                maximum_number_of_processes: PidMax::Value(512),
+                maximum_number_of_processes: MaxValue::Value(512),
             },
             ..Default::default()
         };
@@ -20,7 +21,7 @@ fn pid_resources() {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let pid_max = pidcontroller.get_pid_max();
         assert_eq!(pid_max.is_ok(), true);
-        assert_eq!(pid_max.unwrap(), PidMax::Value(512));
+        assert_eq!(pid_max.unwrap(), MaxValue::Value(512));
     }
     cg.delete();
 }

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -5,7 +5,7 @@
 //
 
 //! Integration test about setting resources using `apply()`
-use cgroups::pid::{PidController};
+use cgroups::pid::PidController;
 use cgroups::{Cgroup, Hierarchy, MaxValue, PidResources, Resources};
 
 #[test]


### PR DESCRIPTION
This PR adds basic cgroup v2 support for Kata containers 2.0

And will fix #1 