### PR TITLE
lib: fix compiling error for type i8 in aarch64 environment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -766,7 +766,7 @@ pub fn nested_keyed_to_hashmap(mut file: File) -> Result<HashMap<String, HashMap
 /// with error: `Os { code: 1, kind: PermissionDenied, message: "Operation not permitted" }`
 pub fn libc_rmdir(p: &str) {
     // with int return value
-    let _ = unsafe { libc::rmdir(p.as_ptr() as *const i8) };
+    let _ = unsafe { libc::rmdir(p.as_ptr() as *const libc::c_char) };
 }
 
 /// read and parse an i64 data


### PR DESCRIPTION
function  libc::rmdir with a  prototype: rmdir(path: *const c_char) -> c_int
and c_char is equal to i8 on x86, but it is equal to u8 on ARM arch,
so we need to use type c_char instead of i8 to avoid compiling error.

Fixes: #9

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>