### PR TITLE
fix build warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - rustup component add rustfmt
 
 script:
-  - cargo build
+  - RUSTFLAGS="--deny warnings" cargo build
   - if [ "$TRAVIS_CPU_ARCH" == "amd64" ]; then cargo test -- --color always --nocapture ; fi
   - cargo fmt -- --check
 

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -396,7 +396,8 @@ impl<'a> From<&'a Subsystem> for &'a BlkIoController {
                 Subsystem::BlkIo(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -43,7 +43,7 @@ impl<'b> Cgroup<'b> {
     /// Create this control group.
     fn create(&self) {
         if self.hier.v2() {
-            create_v2_cgroup(self.hier.root().clone(), &self.path);
+            let _ret = create_v2_cgroup(self.hier.root().clone(), &self.path);
         } else {
             for subsystem in &self.subsystems {
                 subsystem.to_controller().create();
@@ -272,7 +272,7 @@ fn enable_controllers(controllers: &Vec<String>, path: &PathBuf) {
     }
 }
 
-fn supported_controllers(p: &PathBuf) -> Vec<String> {
+fn supported_controllers() -> Vec<String> {
     let p = format!("{}/{}", UNIFIED_MOUNTPOINT, "cgroup.controllers");
     let ret = fs::read_to_string(p.as_str());
     ret.unwrap_or(String::new())
@@ -283,7 +283,7 @@ fn supported_controllers(p: &PathBuf) -> Vec<String> {
 
 fn create_v2_cgroup(root: PathBuf, path: &str) -> Result<()> {
     // controler list ["memory", "cpu"]
-    let controllers = supported_controllers(&root);
+    let controllers = supported_controllers();
     let mut fp = root;
 
     // enable for root

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -60,10 +60,9 @@
 //!          .done()
 //!      .build();
 //! ```
-use crate::error::*;
 
 use crate::{
-    pid, BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, DeviceResource, Hierarchy,
+    BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, DeviceResource, Hierarchy,
     HugePageResource, MaxValue, NetworkPriority, Resources,
 };
 
@@ -141,7 +140,7 @@ impl<'a> CgroupBuilder<'a> {
     /// Finalize the control group, consuming the builder and creating the control group.
     pub fn build(self) -> Cgroup<'a> {
         let cg = Cgroup::new(self.hierarchy, self.name);
-        cg.apply(&self.resources);
+        let _ret = cg.apply(&self.resources);
         cg
     }
 }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -111,7 +111,8 @@ impl<'a> From<&'a Subsystem> for &'a CpuController {
                 Subsystem::Cpu(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -89,7 +89,8 @@ impl<'a> From<&'a Subsystem> for &'a CpuAcctController {
                 Subsystem::CpuAcct(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -125,10 +125,6 @@ impl ControllerInternal for CpuSetController {
             return;
         }
         let current = self.get_path();
-        let parent = match current.parent() {
-            Some(p) => p,
-            None => return,
-        };
 
         if current != self.get_base() {
             match copy_from_parent(current.to_str().unwrap(), "cpuset.cpus") {
@@ -204,7 +200,8 @@ impl<'a> From<&'a Subsystem> for &'a CpuSetController {
                 Subsystem::CpuSet(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -182,7 +182,8 @@ impl<'a> From<&'a Subsystem> for &'a DevicesController {
                 Subsystem::Devices(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,7 +45,7 @@ pub enum ErrorKind {
 #[derive(Debug)]
 pub struct Error {
     kind: ErrorKind,
-    cause: Option<Box<StdError + Send + Sync>>,
+    cause: Option<Box<dyn StdError + Send + Sync>>,
 }
 
 impl fmt::Display for Error {
@@ -67,7 +67,7 @@ impl fmt::Display for Error {
 }
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         match self.cause {
             Some(ref x) => Some(&**x),
             None => None,

--- a/src/events.rs
+++ b/src/events.rs
@@ -60,7 +60,7 @@ fn register_memory_event(
     }
 
     // write to file and set mode to 0700(FIXME)
-    fs::write(&event_control_path, data).map_err(|e| Error::with_cause(WriteFailed, e));
+    fs::write(&event_control_path, data).map_err(|e| Error::with_cause(WriteFailed, e))?;
 
     let mut eventfd_file = unsafe { File::from_raw_fd(eventfd) };
 
@@ -71,7 +71,7 @@ fn register_memory_event(
         loop {
             let mut buf = [0; 8];
             match eventfd_file.read(&mut buf) {
-                Err(err) => {
+                Err(_err) => {
                     return;
                 }
                 Ok(_) => {}

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -73,7 +73,8 @@ impl<'a> From<&'a Subsystem> for &'a FreezerController {
                 Subsystem::Freezer(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -107,7 +107,7 @@ impl Hierarchy for V1 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        let b: &Hierarchy = self as &Hierarchy;
+        let b: &dyn Hierarchy = self as &dyn Hierarchy;
         Cgroup::load(Box::new(&*b), "".to_string())
     }
 
@@ -182,7 +182,7 @@ impl Hierarchy for V2 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        let b: &Hierarchy = self as &Hierarchy;
+        let b: &dyn Hierarchy = self as &dyn Hierarchy;
         Cgroup::load(Box::new(&*b), "".to_string())
     }
 

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -79,7 +79,8 @@ impl<'a> From<&'a Subsystem> for &'a HugeTlbController {
                 Subsystem::HugeTlb(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }
@@ -225,10 +226,15 @@ pub const GB: u128 = 1000 * MB;
 pub const TB: u128 = 1000 * GB;
 pub const PB: u128 = 1000 * TB;
 
+#[allow(non_upper_case_globals)]
 pub const KiB: u128 = 1024;
+#[allow(non_upper_case_globals)]
 pub const MiB: u128 = 1024 * KiB;
+#[allow(non_upper_case_globals)]
 pub const GiB: u128 = 1024 * MiB;
+#[allow(non_upper_case_globals)]
 pub const TiB: u128 = 1024 * GiB;
+#[allow(non_upper_case_globals)]
 pub const PiB: u128 = 1024 * TiB;
 
 pub fn get_binary_size_map() -> HashMap<String, u128> {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -505,10 +505,11 @@ impl MemController {
     // for v2
     pub fn get_mem(&self) -> Result<SetMemory> {
         let mut m: SetMemory = Default::default();
-        self.get_max_value("memory.high").map(|x| m.high = Some(x));
-        self.get_max_value("memory.low").map(|x| m.low = Some(x));
-        self.get_max_value("memory.max").map(|x| m.max = Some(x));
-        self.get_max_value("memory.min").map(|x| m.min = Some(x));
+        self.get_max_value("memory.high")
+            .map(|x| m.high = Some(x))?;
+        self.get_max_value("memory.low").map(|x| m.low = Some(x))?;
+        self.get_max_value("memory.max").map(|x| m.max = Some(x))?;
+        self.get_max_value("memory.min").map(|x| m.min = Some(x))?;
 
         Ok(m)
     }
@@ -831,7 +832,8 @@ impl<'a> From<&'a Subsystem> for &'a MemController {
                 Subsystem::Mem(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -70,7 +70,8 @@ impl<'a> From<&'a Subsystem> for &'a NetClsController {
                 Subsystem::NetCls(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -71,7 +71,8 @@ impl<'a> From<&'a Subsystem> for &'a NetPrioController {
                 Subsystem::NetPrio(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/perf_event.rs
+++ b/src/perf_event.rs
@@ -55,7 +55,8 @@ impl<'a> From<&'a Subsystem> for &'a PerfEventController {
                 Subsystem::PerfEvent(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -85,7 +85,8 @@ impl<'a> From<&'a Subsystem> for &'a PidController {
                 Subsystem::Pid(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -58,7 +58,8 @@ impl<'a> From<&'a Subsystem> for &'a RdmaController {
                 Subsystem::Rdma(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -7,7 +7,6 @@
 //!
 use std::path::PathBuf;
 
-use crate::error::ErrorKind::*;
 use crate::error::*;
 
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
@@ -53,7 +52,8 @@ impl<'a> From<&'a Subsystem> for &'a SystemdController {
                 Subsystem::Systemd(c) => c,
                 _ => {
                     assert_eq!(1, 0);
-                    ::std::mem::uninitialized()
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
                 }
             }
         }


### PR DESCRIPTION
And in Travis CI, treat warnings as error
to keep from merging codes with warning.

Fixes: #13

Signed-off-by: bin liu <bin@hyper.sh>