### PR TITLE
add basic GitHub workflow for basic checks

### DIFF
--- a/.github/workflows/PR-wip-checks.yaml
+++ b/.github/workflows/PR-wip-checks.yaml
@@ -1,0 +1,21 @@
+name: Pull request WIP checks
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+
+jobs:
+  pr_wip_check:
+    runs-on: ubuntu-latest
+    name: WIP Check
+    steps:
+    - name: WIP Check
+      uses: tim-actions/wip-check@1c2a1ca6c110026b3e2297bb2ef39e1747b5a755
+      with:
+        labels: '["do-not-merge", "wip", "rfc"]'
+        keywords: '["WIP", "wip", "RFC", "rfc", "dnm", "DNM", "do-not-merge"]'

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -1,0 +1,53 @@
+name: Commit Message Check
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+env:
+  error_msg: |+
+    See the document below for help on formatting commits for the project.
+
+    https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#patch-forma
+
+jobs:
+  commit-message-check:
+    runs-on: ubuntu-latest
+    name: Commit Message Check
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: DCO Check
+      uses: tim-actions/dco@2fd0504dc0d27b33f542867c300c60840c6dcb20
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+    - name: Commit Body Missing Check
+      if: ${{ success() || failure() }}
+      uses: tim-actions/commit-body-check@v1.0.2
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+
+    - name: Check Subject Line Length
+      if: ${{ success() || failure() }}
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        pattern: '^.{0,75}(\n.*)*$'
+        error: 'Subject too long (max 75)'
+        post_error: ${{ env.error_msg }}
+
+    - name: Check Body Line Length
+      if: ${{ success() || failure() }}
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+        pattern: '^.+(\n.{0,72})*$|^.+\n\s*[^a-zA-Z\s\n]|^.+\n\S+$'
+        error: 'Body line too long (max 72)'
+        post_error: ${{ env.error_msg }}


### PR DESCRIPTION
Basic checks includes:

- Must have commit title/body
- Must have DCO(SoC)
- Title/Body line length are limited 75/72
- Add wip/do-not-merge to label PRs that could be merged

Signed-off-by: bin liu <bin@hyper.sh>