### PR TITLE
Ready to release 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4"
 regex = "1.1"
 nix = "0.18.0"
 libc = "0.2"
+procinfo = "0.4.2"
 
 [dev-dependencies]
 libc = "0.2.76"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ repository = "https://github.com/levex/cgroups-rs"
 keywords = ["linux", "cgroup", "containers", "isolation"]
 categories = ["os", "api-bindings", "os::unix-apis"]
 license = "MIT OR Apache-2.0"
-version = "0.1.1-alpha.0"
+version = "0.2.0"
 authors = ["Levente Kurusa <lkurusa@acm.org>", "Sam Wilson <tecywiz121@hotmail.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -9,24 +9,29 @@ is planned for the Unified hierarchy.
 ## Create a control group using the builder pattern
 
 ``` rust
-// Acquire a handle for the V1 cgroup hierarchy.
-let hier = ::hierarchies::V1::new();
+
+
+use cgroups::*;
+use cgroups::cgroup_builder::*;
+
+// Acquire a handle for the cgroup hierarchy.
+let hier = cgroups::hierarchies::auto();
 
 // Use the builder pattern (see the documentation to create the control group)
 //
 // This creates a control group named "example" in the V1 hierarchy.
-let cg: Cgroup = CgroupBuilder::new("example", &v1)
-	.cpu()
-		.shares(85)
-		.done()
-	.build();
+    let cg: Cgroup = CgroupBuilder::new("example")
+        .cpu()
+        .shares(85)
+        .done()
+        .build(hier);
 
 // Now `cg` is a control group that gets 85% of the CPU time in relative to
 // other control groups.
 
 // Get a handle to the CPU controller.
-let cpus: &CpuController = cg.controller_of().unwrap();
-cpus.add_task(1234u64);
+let cpus: &cgroups::cpu::CpuController = cg.controller_of().unwrap();
+cpus.add_task(&CgroupPid::from(1234u64));
 
 // [...]
 

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -344,39 +344,36 @@ impl ControllerInternal for BlkIoController {
         // get the resources that apply to this controller
         let res: &BlkIoResources = &res.blkio;
 
-        if res.update_values {
-            if let Some(weight) = res.weight {
-                let _ = self.set_weight(weight as u64);
-            }
-            if let Some(leaf_weight) = res.leaf_weight {
-                let _ = self.set_leaf_weight(leaf_weight as u64);
-            }
+        if let Some(weight) = res.weight {
+            let _ = self.set_weight(weight as u64);
+        }
+        if let Some(leaf_weight) = res.leaf_weight {
+            let _ = self.set_leaf_weight(leaf_weight as u64);
+        }
 
-            for dev in &res.weight_device {
-                if let Some(weight) = dev.weight {
-                    let _ = self.set_weight_for_device(dev.major, dev.minor, weight as u64);
-                }
-                if let Some(leaf_weight) = dev.leaf_weight {
-                    let _ =
-                        self.set_leaf_weight_for_device(dev.major, dev.minor, leaf_weight as u64);
-                }
+        for dev in &res.weight_device {
+            if let Some(weight) = dev.weight {
+                let _ = self.set_weight_for_device(dev.major, dev.minor, weight as u64);
             }
+            if let Some(leaf_weight) = dev.leaf_weight {
+                let _ = self.set_leaf_weight_for_device(dev.major, dev.minor, leaf_weight as u64);
+            }
+        }
 
-            for dev in &res.throttle_read_bps_device {
-                let _ = self.throttle_read_bps_for_device(dev.major, dev.minor, dev.rate);
-            }
+        for dev in &res.throttle_read_bps_device {
+            let _ = self.throttle_read_bps_for_device(dev.major, dev.minor, dev.rate);
+        }
 
-            for dev in &res.throttle_write_bps_device {
-                let _ = self.throttle_write_bps_for_device(dev.major, dev.minor, dev.rate);
-            }
+        for dev in &res.throttle_write_bps_device {
+            let _ = self.throttle_write_bps_for_device(dev.major, dev.minor, dev.rate);
+        }
 
-            for dev in &res.throttle_read_iops_device {
-                let _ = self.throttle_read_iops_for_device(dev.major, dev.minor, dev.rate);
-            }
+        for dev in &res.throttle_read_iops_device {
+            let _ = self.throttle_read_iops_for_device(dev.major, dev.minor, dev.rate);
+        }
 
-            for dev in &res.throttle_write_iops_device {
-                let _ = self.throttle_write_iops_for_device(dev.major, dev.minor, dev.rate);
-            }
+        for dev in &res.throttle_write_iops_device {
+            let _ = self.throttle_write_iops_for_device(dev.major, dev.minor, dev.rate);
         }
 
         Ok(())

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -421,12 +421,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 }
 
 impl BlkIoController {
-    /// Constructs a new `BlkIoController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Constructs a new `BlkIoController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -33,7 +33,7 @@ pub struct Cgroup<'b> {
     subsystems: Vec<Subsystem>,
 
     /// The hierarchy.
-    hier: Box<&'b dyn Hierarchy>,
+    hier: &'b dyn Hierarchy,
     path: String,
 }
 
@@ -59,7 +59,7 @@ impl<'b> Cgroup<'b> {
     ///
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
-    pub fn new<P: AsRef<Path>>(hier: Box<&'b dyn Hierarchy>, path: P) -> Cgroup<'b> {
+    pub fn new<P: AsRef<Path>>(hier: &dyn Hierarchy, path: P) -> Cgroup {
         let cg = Cgroup::load(hier, path);
         cg.create();
         cg
@@ -72,10 +72,10 @@ impl<'b> Cgroup<'b> {
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
     pub fn new_with_relative_paths<P: AsRef<Path>>(
-        hier: Box<&'b dyn Hierarchy>,
+        hier: &dyn Hierarchy,
         path: P,
         relative_paths: HashMap<String, String>,
-    ) -> Cgroup<'b> {
+    ) -> Cgroup {
         let cg = Cgroup::load_with_relative_paths(hier, path, relative_paths);
         cg.create();
         cg
@@ -88,7 +88,7 @@ impl<'b> Cgroup<'b> {
     ///
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
-    pub fn load<P: AsRef<Path>>(hier: Box<&'b dyn Hierarchy>, path: P) -> Cgroup {
+    pub fn load<P: AsRef<Path>>(hier: &dyn Hierarchy, path: P) -> Cgroup {
         let path = path.as_ref();
         let mut subsystems = hier.subsystems();
         if path.as_os_str() != "" {
@@ -115,10 +115,10 @@ impl<'b> Cgroup<'b> {
     /// Note that if the handle goes out of scope and is dropped, the control group is _not_
     /// destroyed.
     pub fn load_with_relative_paths<P: AsRef<Path>>(
-        hier: Box<&'b dyn Hierarchy>,
+        hier: &dyn Hierarchy,
         path: P,
         relative_paths: HashMap<String, String>,
-    ) -> Cgroup<'b> {
+    ) -> Cgroup {
         let path = path.as_ref();
         let mut subsystems = hier.subsystems();
         if path.as_os_str() != "" {

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -86,6 +86,8 @@ impl Cgroup {
     /// Create a new control group in the hierarchy `hier`, with name `path` and `relative_paths`
     ///
     /// Returns a handle to the control group that can be used to manipulate it.
+    ///
+    /// Note that this method is only meaningful for cgroup v1, call it is equivalent to call `new` in the v2 mode
     pub fn new_with_relative_paths<P: AsRef<Path>>(
         hier: Box<dyn Hierarchy>,
         path: P,
@@ -123,11 +125,18 @@ impl Cgroup {
     ///
     /// Returns a handle to the control group (that possibly does not exist until `create()` has
     /// been called on the cgroup.
+    ///
+    /// Note that this method is only meaningful for cgroup v1, call it is equivalent to call `load` in the v2 mode
     pub fn load_with_relative_paths<P: AsRef<Path>>(
         hier: Box<dyn Hierarchy>,
         path: P,
         relative_paths: HashMap<String, String>,
     ) -> Cgroup {
+        // relative_paths only valid for cgroup v1
+        if hier.v2() {
+            return Self::load(hier, path);
+        }
+
         let path = path.as_ref();
         let mut subsystems = hier.subsystems();
         if path.as_os_str() != "" {

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -260,6 +260,22 @@ impl Cgroup {
             .try_for_each(|sub| sub.to_controller().add_task_by_tgid(&pid))
     }
 
+    /// Set notify_on_release to the control group.
+    pub fn set_notify_on_release(&self, enable: bool) -> Result<()> {
+        self.subsystems()
+            .iter()
+            .try_for_each(|sub| sub.to_controller().set_notify_on_release(enable))
+    }
+
+    /// Set release_agent
+    pub fn set_release_agent(&self, path: &str) -> Result<()> {
+        self.hier
+            .root_control_group()
+            .subsystems()
+            .iter()
+            .try_for_each(|sub| sub.to_controller().set_release_agent(path))
+    }
+
     /// Returns an Iterator that can be used to iterate over the tasks that are currently in the
     /// control group.
     pub fn tasks(&self) -> Vec<CgroupPid> {

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -233,6 +233,13 @@ impl<'b> Cgroup<'b> {
         }
     }
 
+    /// Attach a task to the control group by thread group id.
+    pub fn add_task_by_tgid(&self, pid: CgroupPid) -> Result<()> {
+        self.subsystems()
+            .iter()
+            .try_for_each(|sub| sub.to_controller().add_task_by_tgid(&pid))
+    }
+
     /// Returns an Iterator that can be used to iterate over the tasks that are currently in the
     /// control group.
     pub fn tasks(&self) -> Vec<CgroupPid> {

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -138,7 +138,7 @@ impl<'a> CgroupBuilder<'a> {
 
     /// Finalize the control group, consuming the builder and creating the control group.
     pub fn build(self) -> Cgroup<'a> {
-        let cg = Cgroup::new(self.hierarchy, self.name);
+        let cg = Cgroup::new(*self.hierarchy, self.name);
         let _ret = cg.apply(&self.resources);
         cg
     }

--- a/src/cgroup_builder.rs
+++ b/src/cgroup_builder.rs
@@ -20,8 +20,7 @@
 //! # use cgroups::devices::*;
 //! # use cgroups::cgroup_builder::*;
 //! let h = cgroups::hierarchies::auto();
-//! let h = Box::new(&*h);
-//! let cgroup: Cgroup = CgroupBuilder::new("hello", h)
+//! let cgroup: Cgroup = CgroupBuilder::new("hello")
 //!      .memory()
 //!          .kernel_memory_limit(1024 * 1024)
 //!          .memory_hard_limit(1024 * 1024)
@@ -58,7 +57,7 @@
 //!              .read(6, 1, 10)
 //!              .write(11, 1, 100)
 //!          .done()
-//!      .build();
+//!      .build(h);
 //! ```
 
 use crate::{

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -18,8 +18,8 @@ use crate::error::*;
 use crate::{parse_max_value, read_i64_from};
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, CpuResources, MaxValue, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, CpuResources, CustomizedAttribute,
+    MaxValue, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `cpu` subsystem of a Cgroup.
@@ -90,6 +90,10 @@ impl ControllerInternal for CpuController {
             if self.cfs_quota()? != res.quota {
                 return Err(Error::new(ErrorKind::Other));
             }
+
+            res.attrs.iter().for_each(|(k, v)| {
+                let _ = self.set(k, v);
+            })
 
             // TODO: rt properties (CONFIG_RT_GROUP_SCHED) are not yet supported
         }
@@ -305,6 +309,8 @@ impl CpuController {
             })
     }
 }
+
+impl CustomizedAttribute for CpuController {}
 
 fn parse_cfs_quota_and_period(mut file: File) -> Result<CFSQuotaAndPeriod> {
     let mut content = String::new();

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -75,28 +75,15 @@ impl ControllerInternal for CpuController {
         // get the resources that apply to this controller
         let res: &CpuResources = &res.cpu;
 
-        if res.update_values {
-            let _ = self.set_shares(res.shares);
-            if self.shares()? != res.shares as u64 {
-                return Err(Error::new(ErrorKind::Other));
-            }
+        update_and_test!(self, set_shares, res.shares, shares);
+        update_and_test!(self, set_cfs_period, res.period, cfs_period);
+        update_and_test!(self, set_cfs_quota, res.quota, cfs_quota);
 
-            let _ = self.set_cfs_period(res.period);
-            if self.cfs_period()? != res.period as u64 {
-                return Err(Error::new(ErrorKind::Other));
-            }
+        res.attrs.iter().for_each(|(k, v)| {
+            let _ = self.set(k, v);
+        });
 
-            let _ = self.set_cfs_quota(res.quota);
-            if self.cfs_quota()? != res.quota {
-                return Err(Error::new(ErrorKind::Other));
-            }
-
-            res.attrs.iter().for_each(|(k, v)| {
-                let _ = self.set(k, v);
-            })
-
-            // TODO: rt properties (CONFIG_RT_GROUP_SCHED) are not yet supported
-        }
+        // TODO: rt properties (CONFIG_RT_GROUP_SCHED) are not yet supported
 
         Ok(())
     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -122,12 +122,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 }
 
 impl CpuController {
-    /// Contructs a new `CpuController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Contructs a new `CpuController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -118,10 +118,8 @@ fn read_string_from(mut file: File) -> Result<String> {
 }
 
 impl CpuAcctController {
-    /// Contructs a new `CpuAcctController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
-        let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+    /// Contructs a new `CpuAcctController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -110,12 +110,8 @@ impl ControllerInternal for CpuSetController {
         // get the resources that apply to this controller
         let res: &CpuResources = &res.cpu;
 
-        if res.update_values {
-            if res.cpus.is_some() {
-                let _ = self.set_cpus(res.cpus.as_ref().unwrap().as_str());
-            }
-            let _ = self.set_mems(&res.mems);
-        }
+        update!(self, set_cpus, res.cpus.as_ref());
+        update!(self, set_mems, res.mems.as_ref());
 
         Ok(())
     }

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -261,12 +261,8 @@ fn parse_range(s: String) -> Result<Vec<(u64, u64)>> {
 }
 
 impl CpuSetController {
-    /// Contructs a new `CpuSetController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Contructs a new `CpuSetController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -189,10 +189,8 @@ impl<'a> From<&'a Subsystem> for &'a DevicesController {
 }
 
 impl DevicesController {
-    /// Constructs a new `DevicesController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
-        let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+    /// Constructs a new `DevicesController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -155,13 +155,11 @@ impl ControllerInternal for DevicesController {
         // get the resources that apply to this controller
         let res: &DeviceResources = &res.devices;
 
-        if res.update_values {
-            for i in &res.devices {
-                if i.allow {
-                    let _ = self.allow_device(i.devtype, i.major, i.minor, &i.access);
-                } else {
-                    let _ = self.deny_device(i.devtype, i.major, i.minor, &i.access);
-                }
+        for i in &res.devices {
+            if i.allow {
+                let _ = self.allow_device(i.devtype, i.major, i.minor, &i.access);
+            } else {
+                let _ = self.deny_device(i.devtype, i.major, i.minor, &i.access);
             }
         }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum ErrorKind {
     /// An error occured while trying to read from a control group file.
     ReadFailed,
 
+    /// An error occured while trying to remove a control group.
+    RemoveFailed,
+
     /// An error occured while trying to parse a value from a control group file.
     ///
     /// In the future, there will be some information attached to this field.
@@ -55,6 +58,7 @@ impl fmt::Display for Error {
             ErrorKind::Common(s) => s.clone(),
             ErrorKind::WriteFailed => "unable to write to a control group file".to_string(),
             ErrorKind::ReadFailed => "unable to read a control group file".to_string(),
+            ErrorKind::RemoveFailed => "unable to remove a control group".to_string(),
             ErrorKind::ParseError => "unable to parse control group file".to_string(),
             ErrorKind::InvalidOperation => "the requested operation is invalid".to_string(),
             ErrorKind::InvalidPath => "the given path is invalid".to_string(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -66,7 +66,11 @@ impl fmt::Display for Error {
             ErrorKind::Other => "an unknown error".to_string(),
         };
 
-        write!(f, "{}", msg)
+        if let Some(cause) = &self.cause {
+            write!(f, "{} caused by: {:?}", msg, cause)
+        } else {
+            write!(f, "{}", msg)
+        }
     }
 }
 

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -82,12 +82,8 @@ impl<'a> From<&'a Subsystem> for &'a FreezerController {
 }
 
 impl FreezerController {
-    /// Contructs a new `FreezerController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Contructs a new `FreezerController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -265,7 +265,7 @@ pub fn auto() -> Box<dyn Hierarchy> {
     }
 }
 
-fn find_v1_mount() -> Option<String> {
+pub fn find_v1_mount() -> Option<String> {
     // Open mountinfo so we can get a parseable mount list
     let mountinfo_path = Path::new("/proc/self/mountinfo");
 

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -32,10 +32,12 @@ use crate::{Controllers, Hierarchy, Subsystem};
 use crate::cgroup::Cgroup;
 
 /// The standard, original cgroup implementation. Often referred to as "cgroupv1".
+#[derive(Debug)]
 pub struct V1 {
     mountinfo: Vec<Mountinfo>,
 }
 
+#[derive(Debug)]
 pub struct V2 {
     root: String,
 }
@@ -98,8 +100,7 @@ impl Hierarchy for V1 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        let b: &dyn Hierarchy = self as &dyn Hierarchy;
-        Cgroup::load(&*b, "".to_string())
+        Cgroup::load(auto(), "".to_string())
     }
 
     fn root(&self) -> PathBuf {
@@ -170,8 +171,7 @@ impl Hierarchy for V2 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        let b: &dyn Hierarchy = self as &dyn Hierarchy;
-        Cgroup::load(&*b, "".to_string())
+        Cgroup::load(auto(), "".to_string())
     }
 
     fn root(&self) -> PathBuf {

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -111,7 +111,7 @@ impl Hierarchy for V1 {
 
     fn root_control_group(&self) -> Cgroup {
         let b: &dyn Hierarchy = self as &dyn Hierarchy;
-        Cgroup::load(Box::new(&*b), "".to_string())
+        Cgroup::load(&*b, "".to_string())
     }
 
     fn check_support(&self, sub: Controllers) -> bool {
@@ -186,7 +186,7 @@ impl Hierarchy for V2 {
 
     fn root_control_group(&self) -> Cgroup {
         let b: &dyn Hierarchy = self as &dyn Hierarchy;
-        Cgroup::load(Box::new(&*b), "".to_string())
+        Cgroup::load(&*b, "".to_string())
     }
 
     fn check_support(&self, _sub: Controllers) -> bool {

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -50,11 +50,18 @@ impl Hierarchy for V1 {
 
     fn subsystems(&self) -> Vec<Subsystem> {
         let mut subs = vec![];
-        if self.check_support(Controllers::Pids) {
-            subs.push(Subsystem::Pid(PidController::new(self.root(), false)));
+
+        // The cgroup writeback feature requires cooperation between memcgs and blkcgs
+        // To avoid exceptions, we should add_task for blkcg before memcg(push BlkIo before Mem)
+        // For more Information: https://www.alibabacloud.com/help/doc-detail/155509.htm
+        if self.check_support(Controllers::BlkIo) {
+            subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), false)));
         }
         if self.check_support(Controllers::Mem) {
             subs.push(Subsystem::Mem(MemController::new(self.root(), false)));
+        }
+        if self.check_support(Controllers::Pids) {
+            subs.push(Subsystem::Pid(PidController::new(self.root(), false)));
         }
         if self.check_support(Controllers::CpuSet) {
             subs.push(Subsystem::CpuSet(CpuSetController::new(self.root(), false)));
@@ -76,9 +83,6 @@ impl Hierarchy for V1 {
         }
         if self.check_support(Controllers::NetCls) {
             subs.push(Subsystem::NetCls(NetClsController::new(self.root())));
-        }
-        if self.check_support(Controllers::BlkIo) {
-            subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), false)));
         }
         if self.check_support(Controllers::PerfEvent) {
             subs.push(Subsystem::PerfEvent(PerfEventController::new(self.root())));

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -9,12 +9,9 @@
 //! Currently, we only support the cgroupv1 hierarchy, but in the future we will add support for
 //! the Unified Hierarchy.
 
-use std::fs::{self, File};
-use std::io::BufRead;
-use std::io::BufReader;
-use std::path::{Path, PathBuf};
-
-use log::*;
+use procinfo::pid::{mountinfo_self, Mountinfo};
+use std::fs;
+use std::path::PathBuf;
 
 use crate::blkio::BlkIoController;
 use crate::cpu::CpuController;
@@ -36,7 +33,7 @@ use crate::cgroup::Cgroup;
 
 /// The standard, original cgroup implementation. Often referred to as "cgroupv1".
 pub struct V1 {
-    mount_point: String,
+    mountinfo: Vec<Mountinfo>,
 }
 
 pub struct V2 {
@@ -54,56 +51,47 @@ impl Hierarchy for V1 {
         // The cgroup writeback feature requires cooperation between memcgs and blkcgs
         // To avoid exceptions, we should add_task for blkcg before memcg(push BlkIo before Mem)
         // For more Information: https://www.alibabacloud.com/help/doc-detail/155509.htm
-        if self.check_support(Controllers::BlkIo) {
-            subs.push(Subsystem::BlkIo(BlkIoController::new(self.root(), false)));
+        if let Some(root) = self.get_mount_point(Controllers::BlkIo) {
+            subs.push(Subsystem::BlkIo(BlkIoController::new(root, false)));
         }
-        if self.check_support(Controllers::Mem) {
-            subs.push(Subsystem::Mem(MemController::new(self.root(), false)));
+        if let Some(root) = self.get_mount_point(Controllers::Mem) {
+            subs.push(Subsystem::Mem(MemController::new(root, false)));
         }
-        if self.check_support(Controllers::Pids) {
-            subs.push(Subsystem::Pid(PidController::new(self.root(), false)));
+        if let Some(root) = self.get_mount_point(Controllers::Pids) {
+            subs.push(Subsystem::Pid(PidController::new(root, false)));
         }
-        if self.check_support(Controllers::CpuSet) {
-            subs.push(Subsystem::CpuSet(CpuSetController::new(self.root(), false)));
+        if let Some(root) = self.get_mount_point(Controllers::CpuSet) {
+            subs.push(Subsystem::CpuSet(CpuSetController::new(root, false)));
         }
-        if self.check_support(Controllers::CpuAcct) {
-            subs.push(Subsystem::CpuAcct(CpuAcctController::new(self.root())));
+        if let Some(root) = self.get_mount_point(Controllers::CpuAcct) {
+            subs.push(Subsystem::CpuAcct(CpuAcctController::new(root)));
         }
-        if self.check_support(Controllers::Cpu) {
-            subs.push(Subsystem::Cpu(CpuController::new(self.root(), false)));
+        if let Some(root) = self.get_mount_point(Controllers::Cpu) {
+            subs.push(Subsystem::Cpu(CpuController::new(root, false)));
         }
-        if self.check_support(Controllers::Devices) {
-            subs.push(Subsystem::Devices(DevicesController::new(self.root())));
+        if let Some(root) = self.get_mount_point(Controllers::Devices) {
+            subs.push(Subsystem::Devices(DevicesController::new(root)));
         }
-        if self.check_support(Controllers::Freezer) {
-            subs.push(Subsystem::Freezer(FreezerController::new(
-                self.root(),
-                false,
-            )));
+        if let Some(root) = self.get_mount_point(Controllers::Freezer) {
+            subs.push(Subsystem::Freezer(FreezerController::new(root, false)));
         }
-        if self.check_support(Controllers::NetCls) {
-            subs.push(Subsystem::NetCls(NetClsController::new(self.root())));
+        if let Some(root) = self.get_mount_point(Controllers::NetCls) {
+            subs.push(Subsystem::NetCls(NetClsController::new(root)));
         }
-        if self.check_support(Controllers::PerfEvent) {
-            subs.push(Subsystem::PerfEvent(PerfEventController::new(self.root())));
+        if let Some(root) = self.get_mount_point(Controllers::PerfEvent) {
+            subs.push(Subsystem::PerfEvent(PerfEventController::new(root)));
         }
-        if self.check_support(Controllers::NetPrio) {
-            subs.push(Subsystem::NetPrio(NetPrioController::new(self.root())));
+        if let Some(root) = self.get_mount_point(Controllers::NetPrio) {
+            subs.push(Subsystem::NetPrio(NetPrioController::new(root)));
         }
-        if self.check_support(Controllers::HugeTlb) {
-            subs.push(Subsystem::HugeTlb(HugeTlbController::new(
-                self.root(),
-                false,
-            )));
+        if let Some(root) = self.get_mount_point(Controllers::HugeTlb) {
+            subs.push(Subsystem::HugeTlb(HugeTlbController::new(root, false)));
         }
-        if self.check_support(Controllers::Rdma) {
-            subs.push(Subsystem::Rdma(RdmaController::new(self.root())));
+        if let Some(root) = self.get_mount_point(Controllers::Rdma) {
+            subs.push(Subsystem::Rdma(RdmaController::new(root)));
         }
-        if self.check_support(Controllers::Systemd) {
-            subs.push(Subsystem::Systemd(SystemdController::new(
-                self.root(),
-                false,
-            )));
+        if let Some(root) = self.get_mount_point(Controllers::Systemd) {
+            subs.push(Subsystem::Systemd(SystemdController::new(root, false)));
         }
 
         subs
@@ -114,20 +102,17 @@ impl Hierarchy for V1 {
         Cgroup::load(&*b, "".to_string())
     }
 
-    fn check_support(&self, sub: Controllers) -> bool {
-        let root = self.root().read_dir().unwrap();
-        for entry in root {
-            if let Ok(entry) = entry {
-                if entry.file_name().into_string().unwrap() == sub.to_string() {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     fn root(&self) -> PathBuf {
-        PathBuf::from(self.mount_point.clone())
+        self.mountinfo
+            .iter()
+            .find_map(|m| {
+                if m.fs_type.0 == "cgroup" {
+                    return Some(m.mount_point.parent().unwrap());
+                }
+                None
+            })
+            .unwrap()
+            .to_path_buf()
     }
 }
 
@@ -189,10 +174,6 @@ impl Hierarchy for V2 {
         Cgroup::load(&*b, "".to_string())
     }
 
-    fn check_support(&self, _sub: Controllers) -> bool {
-        return false;
-    }
-
     fn root(&self) -> PathBuf {
         PathBuf::from(self.root.clone())
     }
@@ -202,10 +183,18 @@ impl V1 {
     /// Finds where control groups are mounted to and returns a hierarchy in which control groups
     /// can be created.
     pub fn new() -> V1 {
-        let mount_point = find_v1_mount().unwrap();
         V1 {
-            mount_point: mount_point,
+            mountinfo: mountinfo_self().unwrap(),
         }
+    }
+
+    pub fn get_mount_point(&self, controller: Controllers) -> Option<PathBuf> {
+        self.mountinfo.iter().find_map(|m| {
+            if m.fs_type.0 == "cgroup" && m.super_opts.contains(&controller.to_string()) {
+                return Some(m.mount_point.clone());
+            }
+            None
+        })
     }
 }
 
@@ -225,7 +214,7 @@ pub const UNIFIED_MOUNTPOINT: &'static str = "/sys/fs/cgroup";
 pub fn is_cgroup2_unified_mode() -> bool {
     use nix::sys::statfs;
 
-    let path = Path::new(UNIFIED_MOUNTPOINT);
+    let path = std::path::Path::new(UNIFIED_MOUNTPOINT);
     let fs_stat = statfs::statfs(path);
     if fs_stat.is_err() {
         return false;
@@ -263,41 +252,4 @@ pub fn auto() -> Box<dyn Hierarchy> {
     } else {
         Box::new(V1::new())
     }
-}
-
-pub fn find_v1_mount() -> Option<String> {
-    // Open mountinfo so we can get a parseable mount list
-    let mountinfo_path = Path::new("/proc/self/mountinfo");
-
-    // If /proc isn't mounted, or something else happens, then bail out
-    if mountinfo_path.exists() == false {
-        return None;
-    }
-
-    let mountinfo_file = File::open(mountinfo_path).unwrap();
-    let mountinfo_reader = BufReader::new(&mountinfo_file);
-    for _line in mountinfo_reader.lines() {
-        let line = _line.unwrap();
-        let mut fields = line.split_whitespace();
-        let index = line.find(" - ").unwrap();
-        let more_fields = line[index + 3..].split_whitespace().collect::<Vec<_>>();
-        if more_fields.len() == 0 {
-            continue;
-        }
-        if more_fields[0] == "cgroup" {
-            if more_fields.len() < 3 {
-                continue;
-            }
-            let cgroups_mount = fields.nth(4).unwrap();
-            if let Some(parent) = std::path::Path::new(cgroups_mount).parent() {
-                if let Some(path) = parent.as_os_str().to_str() {
-                    debug!("found cgroups {:?} from {:?}", path, cgroups_mount);
-                    return Some(path.to_string());
-                }
-            }
-            continue;
-        }
-    }
-
-    None
 }

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -54,14 +54,13 @@ impl ControllerInternal for HugeTlbController {
         // get the resources that apply to this controller
         let res: &HugePageResources = &res.hugepages;
 
-        if res.update_values {
-            for i in &res.limits {
-                let _ = self.set_limit_in_bytes(&i.size, i.limit);
-                if self.limit_in_bytes(&i.size)? != i.limit {
-                    return Err(Error::new(Other));
-                }
+        for i in &res.limits {
+            let _ = self.set_limit_in_bytes(&i.size, i.limit);
+            if self.limit_in_bytes(&i.size)? != i.limit {
+                return Err(Error::new(Other));
             }
         }
+
         Ok(())
     }
 }

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -98,12 +98,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 }
 
 impl HugeTlbController {
-    /// Constructs a new `HugeTlbController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Constructs a new `HugeTlbController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         let sizes = get_hugepage_sizes().unwrap();
         Self {
             base: root.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,12 @@ pub trait Controller {
     /// Does this controller already exist?
     fn exists(&self) -> bool;
 
+    /// Set notify_on_release
+    fn set_notify_on_release(&self, enable: bool) -> Result<()>;
+
+    /// Set release_agent
+    fn set_release_agent(&self, path: &str) -> Result<()>;
+
     /// Delete the controller.
     fn delete(&self) -> Result<()>;
 
@@ -290,6 +296,22 @@ where
         }
     }
 
+    /// Set notify_on_release
+    fn set_notify_on_release(&self, enable: bool) -> Result<()> {
+        self.open_path("notify_on_release", true)
+            .and_then(|mut file| {
+                write!(file, "{}", enable as i32)
+                    .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+            })
+    }
+
+    /// Set release_agent
+    fn set_release_agent(&self, path: &str) -> Result<()> {
+        self.open_path("release_agent", true).and_then(|mut file| {
+            file.write_all(path.as_bytes())
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+        })
+    }
     /// Does this controller already exist?
     fn exists(&self) -> bool {
         self.get_path().exists()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ use crate::pid::PidController;
 use crate::rdma::RdmaController;
 use crate::systemd::SystemdController;
 
+#[doc(inline)]
 pub use crate::cgroup::Cgroup;
 
 /// Contains all the subsystems that are available in this crate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl Controllers {
             Controllers::NetPrio => return "net_prio".to_string(),
             Controllers::HugeTlb => return "hugetlb".to_string(),
             Controllers::Rdma => return "rdma".to_string(),
-            Controllers::Systemd => return "systemd".to_string(),
+            Controllers::Systemd => return "name=systemd".to_string(),
         }
     }
 }
@@ -367,12 +367,6 @@ pub trait Hierarchy {
     fn root_control_group(&self) -> Cgroup;
 
     fn v2(&self) -> bool;
-
-    /// Checks whether a certain subsystem is supported in the hierarchy.
-    ///
-    /// This is an internal function and should not be used.
-    #[doc(hidden)]
-    fn check_support(&self, sub: Controllers) -> bool;
 }
 
 /// Resource limits for the memory subsystem.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ use crate::systemd::SystemdController;
 pub use crate::cgroup::Cgroup;
 
 /// Contains all the subsystems that are available in this crate.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Subsystem {
     /// Controller for the `Pid` subsystem, see `PidController` for more information.
     Pid(PidController),
@@ -104,7 +104,7 @@ pub enum Subsystem {
 }
 
 #[doc(hidden)]
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, Clone)]
 pub enum Controllers {
     Pids,
     Mem,
@@ -357,7 +357,7 @@ pub trait ControllIdentifier {
 
 /// Control group hierarchy (right now, only V1 is supported, but in the future Unified will be
 /// implemented as well).
-pub trait Hierarchy {
+pub trait Hierarchy: std::fmt::Debug + Send {
     /// Returns what subsystems are supported by the hierarchy.
     fn subsystems(&self) -> Vec<Subsystem>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ where
 
         match ::std::fs::create_dir_all(self.get_path()) {
             Ok(_) => self.post_create(),
-            Err(e) => warn!("error create_dir {:?}", e),
+            Err(e) => warn!("error create_dir: {:?} error: {:?}", self.get_path(), e),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,9 @@ pub trait Controller {
     /// Attach a task to this controller.
     fn add_task(&self, pid: &CgroupPid) -> Result<()>;
 
+    /// Attach a task to this controller.
+    fn add_task_by_tgid(&self, pid: &CgroupPid) -> Result<()>;
+
     /// Get the list of tasks that this controller has.
     fn tasks(&self) -> Vec<CgroupPid>;
 
@@ -273,6 +276,14 @@ where
             file = "cgroup.procs";
         }
         self.open_path(file, true).and_then(|mut file| {
+            file.write_all(pid.pid.to_string().as_ref())
+                .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
+        })
+    }
+
+    /// Attach a task to this controller by thread group id.
+    fn add_task_by_tgid(&self, pid: &CgroupPid) -> Result<()> {
+        self.open_path("cgroup.procs", true).and_then(|mut file| {
             file.write_all(pid.pid.to_string().as_ref())
                 .map_err(|e| Error::with_cause(ErrorKind::WriteFailed, e))
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,13 @@ mod sealed {
         }
 
         fn get(&self, key: &str) -> Result<String> {
-            self.open_path(key, false).and_then(read_str_from)
+            self.open_path(key, false).and_then(|mut file: File| {
+                let mut string = String::new();
+                match file.read_to_string(&mut string) {
+                    Ok(_) => Ok(string.trim().to_owned()),
+                    Err(e) => Err(Error::with_cause(ReadFailed, e)),
+                }
+            })
         }
     }
 }
@@ -827,21 +833,13 @@ pub fn nested_keyed_to_hashmap(mut file: File) -> Result<HashMap<String, HashMap
 }
 
 /// read and parse an i64 data
-pub fn read_i64_from(mut file: File) -> Result<i64> {
+fn read_i64_from(mut file: File) -> Result<i64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => string
             .trim()
             .parse()
             .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
-    }
-}
-
-pub fn read_str_from(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => Ok(string.trim().to_owned()),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -884,8 +884,6 @@ mod tests {
     use crate::memory::{
         parse_memory_stat, parse_numa_stat, parse_oom_control, MemoryStat, NumaStat, OomControl,
     };
-    use std::collections::HashMap;
-
     static GOOD_VALUE: &str = "\
 total=51189 N0=51189 N1=123
 file=50175 N0=50175 N1=123

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -21,8 +21,8 @@ use crate::events;
 use crate::flat_keyed_to_hashmap;
 
 use crate::{
-    ControllIdentifier, ControllerInternal, Controllers, MaxValue, MemoryResources, Resources,
-    Subsystem,
+    ControllIdentifier, ControllerInternal, Controllers, CustomizedAttribute, MaxValue,
+    MemoryResources, Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `memory` subsystem of a Cgroup.
@@ -833,6 +833,8 @@ impl ControllIdentifier for MemController {
         Controllers::Mem
     }
 }
+
+impl CustomizedAttribute for MemController {}
 
 impl<'a> From<&'a Subsystem> for &'a MemController {
     fn from(sub: &'a Subsystem) -> &'a MemController {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -702,6 +702,11 @@ impl MemController {
 
     /// Reset the kernel memory fail counter
     pub fn reset_kmem_fail_count(&self) -> Result<()> {
+        // Ignore kmem because there is no kmem in cgroup v2
+        if self.v2 {
+            return Ok(());
+        }
+
         self.open_path("memory.kmem.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
@@ -711,6 +716,11 @@ impl MemController {
 
     /// Reset the TCP related fail counter
     pub fn reset_tcp_fail_count(&self) -> Result<()> {
+        // Ignore kmem because there is no kmem in cgroup v2
+        if self.v2 {
+            return Ok(());
+        }
+
         self.open_path("memory.kmem.tcp.failcnt", true)
             .and_then(|mut file| {
                 file.write_all("0".to_string().as_ref())
@@ -750,6 +760,11 @@ impl MemController {
 
     /// Set the kernel memory limit of the control group, in bytes.
     pub fn set_kmem_limit(&self, limit: i64) -> Result<()> {
+        // Ignore kmem because there is no kmem in cgroup v2
+        if self.v2 {
+            return Ok(());
+        }
+
         self.open_path("memory.kmem.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())
@@ -771,6 +786,11 @@ impl MemController {
 
     /// Set how much kernel memory can be used for TCP-related buffers by the control group.
     pub fn set_tcp_limit(&self, limit: i64) -> Result<()> {
+        // Ignore kmem because there is no kmem in cgroup v2
+        if self.v2 {
+            return Ok(());
+        }
+
         self.open_path("memory.kmem.tcp.limit_in_bytes", true)
             .and_then(|mut file| {
                 file.write_all(limit.to_string().as_ref())

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -818,11 +818,15 @@ impl MemController {
     ///
     /// Note that a value of zero does not imply that the process will not be swapped out.
     pub fn set_swappiness(&self, swp: u64) -> Result<()> {
-        self.open_path("memory.swappiness", true)
-            .and_then(|mut file| {
-                file.write_all(swp.to_string().as_ref())
-                    .map_err(|e| Error::with_cause(WriteFailed, e))
-            })
+        let mut file = "memory.swappiness";
+        if self.v2 {
+            file = "memory.swap.max"
+        }
+
+        self.open_path(file, true).and_then(|mut file| {
+            file.write_all(swp.to_string().as_ref())
+                .map_err(|e| Error::with_cause(WriteFailed, e))
+        })
     }
 
     pub fn disable_oom_killer(&self) -> Result<()> {

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -17,6 +17,7 @@ use std::sync::mpsc::Receiver;
 use crate::error::ErrorKind::*;
 use crate::error::*;
 use crate::events;
+use crate::read_i64_from;
 
 use crate::flat_keyed_to_hashmap;
 
@@ -870,17 +871,6 @@ impl<'a> From<&'a Subsystem> for &'a MemController {
 }
 
 fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
-    }
-}
-
-fn read_i64_from(mut file: File) -> Result<i64> {
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => string

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -465,12 +465,8 @@ impl ControllerInternal for MemController {
 }
 
 impl MemController {
-    /// Contructs a new `MemController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Contructs a new `MemController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -453,14 +453,12 @@ impl ControllerInternal for MemController {
         // get the resources that apply to this controller
         let memres: &MemoryResources = &res.memory;
 
-        if memres.update_values {
-            let _ = self.set_limit(memres.memory_hard_limit);
-            let _ = self.set_soft_limit(memres.memory_soft_limit);
-            let _ = self.set_kmem_limit(memres.kernel_memory_limit);
-            let _ = self.set_memswap_limit(memres.memory_swap_limit);
-            let _ = self.set_tcp_limit(memres.kernel_tcp_memory_limit);
-            let _ = self.set_swappiness(memres.swappiness);
-        }
+        update!(self, set_limit, memres.memory_hard_limit);
+        update!(self, set_soft_limit, memres.memory_soft_limit);
+        update!(self, set_kmem_limit, memres.kernel_memory_limit);
+        update!(self, set_memswap_limit, memres.memory_swap_limit);
+        update!(self, set_tcp_limit, memres.kernel_tcp_memory_limit);
+        update!(self, set_swappiness, memres.swappiness);
 
         Ok(())
     }

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -86,10 +86,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 }
 
 impl NetClsController {
-    /// Constructs a new `NetClsController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
-        let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+    /// Constructs a new `NetClsController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -47,12 +47,8 @@ impl ControllerInternal for NetClsController {
         // get the resources that apply to this controller
         let res: &NetworkResources = &res.network;
 
-        if res.update_values {
-            let _ = self.set_class(res.class_id);
-            if self.get_class()? != res.class_id {
-                return Err(Error::new(Other));
-            }
-        }
+        update_and_test!(self, set_class, res.class_id, get_class);
+
         return Ok(());
     }
 }

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -48,10 +48,8 @@ impl ControllerInternal for NetPrioController {
         // get the resources that apply to this controller
         let res: &NetworkResources = &res.network;
 
-        if res.update_values {
-            for i in &res.priorities {
-                let _ = self.set_if_prio(&i.name, i.priority);
-            }
+        for i in &res.priorities {
+            let _ = self.set_if_prio(&i.name, i.priority);
         }
 
         Ok(())

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -89,10 +89,8 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 }
 
 impl NetPrioController {
-    /// Constructs a new `NetPrioController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
-        let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+    /// Constructs a new `NetPrioController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/perf_event.rs
+++ b/src/perf_event.rs
@@ -64,10 +64,8 @@ impl<'a> From<&'a Subsystem> for &'a PerfEventController {
 }
 
 impl PerfEventController {
-    /// Constructs a new `PerfEventController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
-        let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+    /// Constructs a new `PerfEventController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -50,17 +50,13 @@ impl ControllerInternal for PidController {
         // get the resources that apply to this controller
         let pidres: &PidResources = &res.pid;
 
-        if pidres.update_values {
-            // apply pid_max
-            let _ = self.set_pid_max(pidres.maximum_number_of_processes);
-
-            // now, verify
-            if self.get_pid_max()? == pidres.maximum_number_of_processes {
-                return Ok(());
-            } else {
-                return Err(Error::new(Other));
-            }
-        }
+        // apply pid_max
+        update_and_test!(
+            self,
+            set_pid_max,
+            pidres.maximum_number_of_processes,
+            get_pid_max
+        );
 
         Ok(())
     }

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -101,13 +101,9 @@ fn read_u64_from(mut file: File) -> Result<u64> {
 }
 
 impl PidController {
-    /// Constructors a new `PidController` instance, with `oroot` serving as the controller's root
+    /// Constructors a new `PidController` instance, with `root` serving as the controller's root
     /// directory.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -75,10 +75,8 @@ fn read_string_from(mut file: File) -> Result<String> {
 }
 
 impl RdmaController {
-    /// Constructs a new `RdmaController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf) -> Self {
-        let mut root = oroot;
-        root.push(Self::controller_type().to_string());
+    /// Constructs a new `RdmaController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -61,12 +61,8 @@ impl<'a> From<&'a Subsystem> for &'a SystemdController {
 }
 
 impl SystemdController {
-    /// Constructs a new `SystemdController` with `oroot` serving as the root of the control group.
-    pub fn new(oroot: PathBuf, v2: bool) -> Self {
-        let mut root = oroot;
-        if !v2 {
-            root.push(Self::controller_type().to_string());
-        }
+    /// Constructs a new `SystemdController` with `root` serving as the root of the control group.
+    pub fn new(root: PathBuf, v2: bool) -> Self {
         Self {
             base: root.clone(),
             path: root,

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -159,7 +159,7 @@ pub fn test_blkio_res_build() {
     let h = Box::new(&*h);
     let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", h)
         .blkio()
-        .weight(Some(100))
+        .weight(100)
         .done()
         .build();
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -31,7 +31,7 @@ pub fn test_cpu_res_build() {
         assert_eq!(cpu.shares().unwrap(), 85);
     }
 
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -55,7 +55,7 @@ pub fn test_memory_res_build() {
         assert_eq!(c.memory_stat().limit_in_bytes, 1024 * 1024 * 1024);
     }
 
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -74,7 +74,7 @@ pub fn test_pid_res_build() {
         assert_eq!(c.get_pid_max().unwrap(), MaxValue::Value(123));
     }
 
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -102,7 +102,7 @@ pub fn test_devices_res_build() {
             }]
         );
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -124,7 +124,7 @@ pub fn test_network_res_build() {
         assert!(c.get_class().is_ok());
         assert_eq!(c.get_class().unwrap(), 1337);
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -149,7 +149,7 @@ pub fn test_hugepages_res_build() {
             4 * 2 * 1024 * 1024
         );
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -167,5 +167,5 @@ pub fn test_blkio_res_build() {
         let c: &BlkIoController = cg.controller_of().unwrap();
         assert_eq!(c.blkio().weight, 100);
     }
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -18,12 +18,11 @@ use cgroups::*;
 #[test]
 pub fn test_cpu_res_build() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_cpu_res_build")
         .cpu()
         .shares(85)
         .done()
-        .build();
+        .build(h);
 
     {
         let cpu: &CpuController = cg.controller_of().unwrap();
@@ -37,14 +36,13 @@ pub fn test_cpu_res_build() {
 #[test]
 pub fn test_memory_res_build() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_memory_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_memory_res_build")
         .memory()
         .kernel_memory_limit(128 * 1024 * 1024)
         .swappiness(70)
         .memory_hard_limit(1024 * 1024 * 1024)
         .done()
-        .build();
+        .build(h);
 
     {
         let c: &MemController = cg.controller_of().unwrap();
@@ -61,12 +59,11 @@ pub fn test_memory_res_build() {
 #[test]
 pub fn test_pid_res_build() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_pid_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_pid_res_build")
         .pid()
         .maximum_number_of_processes(MaxValue::Value(123))
         .done()
-        .build();
+        .build(h);
 
     {
         let c: &PidController = cg.controller_of().unwrap();
@@ -81,12 +78,11 @@ pub fn test_pid_res_build() {
 #[ignore] // ignore this test for now, not sure why my kernel doesn't like it
 pub fn test_devices_res_build() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_devices_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_devices_res_build")
         .devices()
         .device(1, 6, DeviceType::Char, true, vec![DevicePermissions::Read])
         .done()
-        .build();
+        .build(h);
 
     {
         let c: &DevicesController = cg.controller_of().unwrap();
@@ -112,12 +108,11 @@ pub fn test_network_res_build() {
         // FIXME add cases for v2
         return;
     }
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_network_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_network_res_build")
         .network()
         .class_id(1337)
         .done()
-        .build();
+        .build(h);
 
     {
         let c: &NetClsController = cg.controller_of().unwrap();
@@ -134,12 +129,11 @@ pub fn test_hugepages_res_build() {
         // FIXME add cases for v2
         return;
     }
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_hugepages_res_build")
         .hugepages()
         .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
         .done()
-        .build();
+        .build(h);
 
     {
         let c: &HugeTlbController = cg.controller_of().unwrap();
@@ -156,12 +150,11 @@ pub fn test_hugepages_res_build() {
 #[ignore] // high version kernel not support `blkio.weight`
 pub fn test_blkio_res_build() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build", h)
+    let cg: Cgroup = CgroupBuilder::new("test_blkio_res_build")
         .blkio()
         .weight(100)
         .done()
-        .build();
+        .build(h);
 
     {
         let c: &BlkIoController = cg.controller_of().unwrap();

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -5,10 +5,9 @@
 //
 
 //! Simple unit tests about the control groups system.
-use cgroups::memory::{MemController, SetMemory};
+use cgroups::memory::MemController;
 use cgroups::Controller;
-use cgroups::{Cgroup, CgroupPid, Hierarchy, Subsystem};
-use std::collections::HashMap;
+use cgroups::{Cgroup, CgroupPid, Subsystem};
 
 #[test]
 fn test_tasks_iterator() {
@@ -34,7 +33,7 @@ fn test_tasks_iterator() {
         // Verify that it was indeed removed.
         assert_eq!(tasks.next(), None);
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -75,7 +74,7 @@ fn test_cgroup_with_relative_paths() {
             _ => {}
         });
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -102,5 +101,5 @@ fn test_cgroup_v2() {
     println!("memswap {:?}", memswap);
     assert_eq!(swp, memswap.limit_in_bytes);
 
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -13,7 +13,7 @@ use cgroups::{Cgroup, CgroupPid, Subsystem};
 fn test_tasks_iterator() {
     let h = cgroups::hierarchies::auto();
     let pid = libc::pid_t::from(nix::unistd::getpid()) as u64;
-    let cg = Cgroup::new(&*h, String::from("test_tasks_iterator"));
+    let cg = Cgroup::new(h, String::from("test_tasks_iterator"));
     {
         // Add a task to the control group.
         cg.add_task(CgroupPid::from(pid)).unwrap();
@@ -45,7 +45,7 @@ fn test_cgroup_with_relative_paths() {
     let cgroup_root = h.root();
     let cgroup_name = "test_cgroup_with_relative_paths";
 
-    let cg = Cgroup::load(&*h, String::from(cgroup_name));
+    let cg = Cgroup::load(h, String::from(cgroup_name));
     {
         let subsystems = cg.subsystems();
         subsystems.into_iter().for_each(|sub| match sub {
@@ -83,14 +83,14 @@ fn test_cgroup_v2() {
         return;
     }
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::load(&*h, String::from("test_v2"));
+    let cg = Cgroup::new(h, String::from("test_v2"));
 
     let mem_controller: &MemController = cg.controller_of().unwrap();
     let (mem, swp, rev) = (4 * 1024 * 1000, 2 * 1024 * 1000, 1024 * 1000);
 
-    let _ = mem_controller.set_limit(mem);
-    let _ = mem_controller.set_memswap_limit(swp);
-    let _ = mem_controller.set_soft_limit(rev);
+    mem_controller.set_limit(mem).unwrap();
+    mem_controller.set_memswap_limit(swp).unwrap();
+    mem_controller.set_soft_limit(rev).unwrap();
 
     let memory_stat = mem_controller.memory_stat();
     println!("memory_stat {:?}", memory_stat);

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -10,7 +10,7 @@ use cgroups::Cgroup;
 #[test]
 fn test_cfs_quota_and_periods() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_cfs_quota_and_periods"));
+    let cg = Cgroup::new(h, String::from("test_cfs_quota_and_periods"));
 
     let cpu_controller: &CpuController = cg.controller_of().unwrap();
 

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -13,8 +13,7 @@ use std::fs;
 #[test]
 fn test_cfs_quota_and_periods() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_cfs_quota_and_periods"));
+    let cg = Cgroup::new(&*h, String::from("test_cfs_quota_and_periods"));
 
     let cpu_controller: &CpuController = cg.controller_of().unwrap();
 

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -5,10 +5,7 @@
 
 //! Simple unit tests about the CPU control groups system.
 use cgroups::cpu::CpuController;
-use cgroups::error::ErrorKind;
-use cgroups::{Cgroup, CgroupPid, CpuResources, Hierarchy, Resources};
-
-use std::fs;
+use cgroups::Cgroup;
 
 #[test]
 fn test_cfs_quota_and_periods() {
@@ -26,7 +23,7 @@ fn test_cfs_quota_and_periods() {
     assert_eq!(100000, current_peroid);
 
     // case 1 set quota
-    let r = cpu_controller.set_cfs_quota(2000);
+    let _ = cpu_controller.set_cfs_quota(2000);
 
     let current_quota = cpu_controller.cfs_quota().unwrap();
     let current_peroid = cpu_controller.cfs_period().unwrap();
@@ -34,14 +31,16 @@ fn test_cfs_quota_and_periods() {
     assert_eq!(100000, current_peroid);
 
     // case 2 set period
-    cpu_controller.set_cfs_period(1000000);
+    cpu_controller.set_cfs_period(1000000).unwrap();
     let current_quota = cpu_controller.cfs_quota().unwrap();
     let current_peroid = cpu_controller.cfs_period().unwrap();
     assert_eq!(2000, current_quota);
     assert_eq!(1000000, current_peroid);
 
     // case 3 set both quota and period
-    cpu_controller.set_cfs_quota_and_period(Some(5000), Some(100000));
+    cpu_controller
+        .set_cfs_quota_and_period(Some(5000), Some(100000))
+        .unwrap();
 
     let current_quota = cpu_controller.cfs_quota().unwrap();
     let current_peroid = cpu_controller.cfs_period().unwrap();
@@ -49,12 +48,14 @@ fn test_cfs_quota_and_periods() {
     assert_eq!(100000, current_peroid);
 
     // case 4 set both quota and period, set quota to -1
-    cpu_controller.set_cfs_quota_and_period(Some(-1), None);
+    cpu_controller
+        .set_cfs_quota_and_period(Some(-1), None)
+        .unwrap();
 
     let current_quota = cpu_controller.cfs_quota().unwrap();
     let current_peroid = cpu_controller.cfs_period().unwrap();
     assert_eq!(-1, current_quota);
     assert_eq!(100000, current_peroid);
 
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -6,7 +6,7 @@
 
 use cgroups::cpuset::CpuSetController;
 use cgroups::error::ErrorKind;
-use cgroups::{Cgroup, CgroupPid, CpuResources, Hierarchy, Resources};
+use cgroups::{Cgroup, CgroupPid};
 
 use std::fs;
 
@@ -21,7 +21,7 @@ fn test_cpuset_memory_pressure_root_cg() {
         let res = cpuset.set_enable_memory_pressure(true);
         assert_eq!(res.unwrap_err().kind(), &ErrorKind::InvalidOperation);
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -59,7 +59,7 @@ fn test_cpuset_set_cpus() {
             assert_eq!(format!("{}-{}", set.cpus[0].0, set.cpus[0].1), cpus);
         }
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -89,5 +89,5 @@ fn test_cpuset_set_cpus_add_task() {
     println!("tasks after deleted: {:?}", tasks);
     assert_eq!(0, tasks.len());
 
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -13,8 +13,7 @@ use std::fs;
 #[test]
 fn test_cpuset_memory_pressure_root_cg() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_cpuset_memory_pressure_root_cg"));
+    let cg = Cgroup::new(&*h, String::from("test_cpuset_memory_pressure_root_cg"));
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
@@ -28,8 +27,7 @@ fn test_cpuset_memory_pressure_root_cg() {
 #[test]
 fn test_cpuset_set_cpus() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus"));
+    let cg = Cgroup::new(&*h, String::from("test_cpuset_set_cpus"));
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
@@ -67,8 +65,7 @@ fn test_cpuset_set_cpus() {
 #[test]
 fn test_cpuset_set_cpus_add_task() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus_add_task/sub-dir"));
+    let cg = Cgroup::new(&*h, String::from("test_cpuset_set_cpus_add_task/sub-dir"));
 
     let cpuset: &CpuSetController = cg.controller_of().unwrap();
     let set = cpuset.cpuset();

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -13,7 +13,7 @@ use std::fs;
 #[test]
 fn test_cpuset_memory_pressure_root_cg() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_cpuset_memory_pressure_root_cg"));
+    let cg = Cgroup::new(h, String::from("test_cpuset_memory_pressure_root_cg"));
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
@@ -27,7 +27,7 @@ fn test_cpuset_memory_pressure_root_cg() {
 #[test]
 fn test_cpuset_set_cpus() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_cpuset_set_cpus"));
+    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus"));
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
@@ -65,7 +65,7 @@ fn test_cpuset_set_cpus() {
 #[test]
 fn test_cpuset_set_cpus_add_task() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_cpuset_set_cpus_add_task/sub-dir"));
+    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus_add_task/sub-dir"));
 
     let cpuset: &CpuSetController = cg.controller_of().unwrap();
     let set = cpuset.cpuset();

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -7,7 +7,7 @@
 //! Integration tests about the devices subsystem
 
 use cgroups::devices::{DevicePermissions, DeviceType, DevicesController};
-use cgroups::{Cgroup, DeviceResource, Hierarchy};
+use cgroups::{Cgroup, DeviceResource};
 
 #[test]
 fn test_devices_parsing() {
@@ -22,16 +22,18 @@ fn test_devices_parsing() {
         let devices: &DevicesController = cg.controller_of().unwrap();
 
         // Deny access to all devices first
-        devices.deny_device(
-            DeviceType::All,
-            -1,
-            -1,
-            &vec![
-                DevicePermissions::Read,
-                DevicePermissions::Write,
-                DevicePermissions::MkNod,
-            ],
-        );
+        devices
+            .deny_device(
+                DeviceType::All,
+                -1,
+                -1,
+                &vec![
+                    DevicePermissions::Read,
+                    DevicePermissions::Write,
+                    DevicePermissions::MkNod,
+                ],
+            )
+            .unwrap();
         // Acquire the list of allowed devices after we denied all
         let allowed_devices = devices.allowed_devices();
         // Verify that there are no devices that we can access.
@@ -39,7 +41,9 @@ fn test_devices_parsing() {
         assert_eq!(allowed_devices.unwrap(), Vec::new());
 
         // Now add mknod access to /dev/null device
-        devices.allow_device(DeviceType::Char, 1, 3, &vec![DevicePermissions::MkNod]);
+        devices
+            .allow_device(DeviceType::Char, 1, 3, &vec![DevicePermissions::MkNod])
+            .unwrap();
         let allowed_devices = devices.allowed_devices();
         assert!(allowed_devices.is_ok());
         let allowed_devices = allowed_devices.unwrap();
@@ -56,12 +60,14 @@ fn test_devices_parsing() {
         );
 
         // Now deny, this device explicitly.
-        devices.deny_device(DeviceType::Char, 1, 3, &DevicePermissions::all());
+        devices
+            .deny_device(DeviceType::Char, 1, 3, &DevicePermissions::all())
+            .unwrap();
         // Finally, check that.
         let allowed_devices = devices.allowed_devices();
         // Verify that there are no devices that we can access.
         assert!(allowed_devices.is_ok());
         assert_eq!(allowed_devices.unwrap(), Vec::new());
     }
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -17,7 +17,7 @@ fn test_devices_parsing() {
     }
 
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_devices_parsing"));
+    let cg = Cgroup::new(h, String::from("test_devices_parsing"));
     {
         let devices: &DevicesController = cg.controller_of().unwrap();
 

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -17,8 +17,7 @@ fn test_devices_parsing() {
     }
 
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_devices_parsing"));
+    let cg = Cgroup::new(&*h, String::from("test_devices_parsing"));
     {
         let devices: &DevicesController = cg.controller_of().unwrap();
 

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -20,8 +20,7 @@ fn test_hugetlb_sizes() {
     }
 
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_hugetlb_sizes"));
+    let cg = Cgroup::new(&*h, String::from("test_hugetlb_sizes"));
     {
         let hugetlb_controller: &HugeTlbController = cg.controller_of().unwrap();
         let sizes = hugetlb_controller.get_sizes();

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -4,12 +4,9 @@
 //
 
 //! Integration tests about the hugetlb subsystem
-use cgroups::hugetlb::{self, HugeTlbController};
-use cgroups::Controller;
-use cgroups::{Cgroup, Hierarchy};
-
-use cgroups::error::ErrorKind::*;
 use cgroups::error::*;
+use cgroups::hugetlb::{self, HugeTlbController};
+use cgroups::Cgroup;
 use std::fs;
 
 #[test]
@@ -23,7 +20,7 @@ fn test_hugetlb_sizes() {
     let cg = Cgroup::new(&*h, String::from("test_hugetlb_sizes"));
     {
         let hugetlb_controller: &HugeTlbController = cg.controller_of().unwrap();
-        let sizes = hugetlb_controller.get_sizes();
+        let _ = hugetlb_controller.get_sizes();
 
         // test sizes count
         let sizes = hugetlb_controller.get_sizes();
@@ -39,7 +36,7 @@ fn test_hugetlb_sizes() {
             assert_no_error(hugetlb_controller.max_usage_in_bytes(&size));
         }
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 fn assert_no_error(r: Result<u64>) {

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -17,7 +17,7 @@ fn test_hugetlb_sizes() {
     }
 
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_hugetlb_sizes"));
+    let cg = Cgroup::new(h, String::from("test_hugetlb_sizes"));
     {
         let hugetlb_controller: &HugeTlbController = cg.controller_of().unwrap();
         let _ = hugetlb_controller.get_sizes();

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -30,7 +30,7 @@ fn test_disable_oom_killer() {
             assert_eq!(m.oom_control.oom_kill_disable, true);
         }
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -87,5 +87,5 @@ fn set_mem_v2() {
         assert_eq!(m.high, Some(MaxValue::Max));
     }
 
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -11,7 +11,7 @@ use cgroups::{Cgroup, MaxValue};
 #[test]
 fn test_disable_oom_killer() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_disable_oom_killer"));
+    let cg = Cgroup::new(h, String::from("test_disable_oom_killer"));
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 
@@ -40,7 +40,7 @@ fn set_mem_v2() {
         return;
     }
 
-    let cg = Cgroup::new(&*h, String::from("set_mem_v2"));
+    let cg = Cgroup::new(h, String::from("set_mem_v2"));
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -11,8 +11,7 @@ use cgroups::{Cgroup, MaxValue};
 #[test]
 fn test_disable_oom_killer() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_disable_oom_killer"));
+    let cg = Cgroup::new(&*h, String::from("test_disable_oom_killer"));
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 
@@ -41,8 +40,7 @@ fn set_mem_v2() {
         return;
     }
 
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("set_mem_v2"));
+    let cg = Cgroup::new(&*h, String::from("set_mem_v2"));
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -19,8 +19,7 @@ use std::thread;
 #[test]
 fn create_and_delete_cgroup() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("create_and_delete_cgroup"));
+    let cg = Cgroup::new(&*h, String::from("create_and_delete_cgroup"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         pidcontroller.set_pid_max(MaxValue::Value(1337));
@@ -34,8 +33,7 @@ fn create_and_delete_cgroup() {
 #[test]
 fn test_pids_current_is_zero() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_pids_current_is_zero"));
+    let cg = Cgroup::new(&*h, String::from("test_pids_current_is_zero"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let current = pidcontroller.get_pid_current();
@@ -47,8 +45,7 @@ fn test_pids_current_is_zero() {
 #[test]
 fn test_pids_events_is_zero() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_pids_events_is_zero"));
+    let cg = Cgroup::new(&*h, String::from("test_pids_events_is_zero"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let events = pidcontroller.get_pid_events();
@@ -61,8 +58,7 @@ fn test_pids_events_is_zero() {
 #[test]
 fn test_pid_events_is_not_zero() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("test_pid_events_is_not_zero"));
+    let cg = Cgroup::new(&*h, String::from("test_pid_events_is_not_zero"));
     {
         let pids: &PidController = cg.controller_of().unwrap();
         let before = pids.get_pid_events();

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -17,7 +17,7 @@ use libc::pid_t;
 #[test]
 fn create_and_delete_cgroup() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("create_and_delete_cgroup"));
+    let cg = Cgroup::new(h, String::from("create_and_delete_cgroup"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         pidcontroller.set_pid_max(MaxValue::Value(1337)).unwrap();
@@ -31,7 +31,7 @@ fn create_and_delete_cgroup() {
 #[test]
 fn test_pids_current_is_zero() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_pids_current_is_zero"));
+    let cg = Cgroup::new(h, String::from("test_pids_current_is_zero"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let current = pidcontroller.get_pid_current();
@@ -43,7 +43,7 @@ fn test_pids_current_is_zero() {
 #[test]
 fn test_pids_events_is_zero() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_pids_events_is_zero"));
+    let cg = Cgroup::new(h, String::from("test_pids_events_is_zero"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let events = pidcontroller.get_pid_events();
@@ -56,7 +56,7 @@ fn test_pids_events_is_zero() {
 #[test]
 fn test_pid_events_is_not_zero() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("test_pid_events_is_not_zero"));
+    let cg = Cgroup::new(h, String::from("test_pid_events_is_not_zero"));
     {
         let pids: &PidController = cg.controller_of().unwrap();
         let before = pids.get_pid_events();

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -7,14 +7,12 @@
 //! Integration tests about the pids subsystem
 use cgroups::pid::PidController;
 use cgroups::Controller;
-use cgroups::{Cgroup, CgroupPid, Hierarchy, MaxValue, PidResources, Resources};
+use cgroups::{Cgroup, MaxValue};
 
 use nix::sys::wait::{waitpid, WaitStatus};
-use nix::unistd::{fork, ForkResult, Pid};
+use nix::unistd::{fork, ForkResult};
 
 use libc::pid_t;
-
-use std::thread;
 
 #[test]
 fn create_and_delete_cgroup() {
@@ -22,12 +20,12 @@ fn create_and_delete_cgroup() {
     let cg = Cgroup::new(&*h, String::from("create_and_delete_cgroup"));
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
-        pidcontroller.set_pid_max(MaxValue::Value(1337));
+        pidcontroller.set_pid_max(MaxValue::Value(1337)).unwrap();
         let max = pidcontroller.get_pid_max();
         assert!(max.is_ok());
         assert_eq!(max.unwrap(), MaxValue::Value(1337));
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -39,7 +37,7 @@ fn test_pids_current_is_zero() {
         let current = pidcontroller.get_pid_current();
         assert_eq!(current.unwrap(), 0);
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -52,7 +50,7 @@ fn test_pids_events_is_zero() {
         assert!(events.is_ok());
         assert_eq!(events.unwrap(), 0);
     }
-    cg.delete();
+    cg.delete().unwrap();
 }
 
 #[test]
@@ -101,5 +99,5 @@ fn test_pid_events_is_not_zero() {
             Err(_) => panic!("failed to fork"),
         }
     }
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -6,7 +6,7 @@
 
 //! Integration test about setting resources using `apply()`
 use cgroups::pid::PidController;
-use cgroups::{Cgroup, Hierarchy, MaxValue, PidResources, Resources};
+use cgroups::{Cgroup, MaxValue, PidResources, Resources};
 
 #[test]
 fn pid_resources() {
@@ -19,7 +19,7 @@ fn pid_resources() {
             },
             ..Default::default()
         };
-        cg.apply(&res);
+        cg.apply(&res).unwrap();
 
         // verify
         let pidcontroller: &PidController = cg.controller_of().unwrap();
@@ -27,5 +27,5 @@ fn pid_resources() {
         assert_eq!(pid_max.is_ok(), true);
         assert_eq!(pid_max.unwrap(), MaxValue::Value(512));
     }
-    cg.delete();
+    cg.delete().unwrap();
 }

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -16,8 +16,7 @@ fn pid_resources() {
     {
         let res = Resources {
             pid: PidResources {
-                update_values: true,
-                maximum_number_of_processes: MaxValue::Value(512),
+                maximum_number_of_processes: Some(MaxValue::Value(512)),
             },
             ..Default::default()
         };

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -11,7 +11,7 @@ use cgroups::{Cgroup, MaxValue, PidResources, Resources};
 #[test]
 fn pid_resources() {
     let h = cgroups::hierarchies::auto();
-    let cg = Cgroup::new(&*h, String::from("pid_resources"));
+    let cg = Cgroup::new(h, String::from("pid_resources"));
     {
         let res = Resources {
             pid: PidResources {

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -11,8 +11,7 @@ use cgroups::{Cgroup, Hierarchy, MaxValue, PidResources, Resources};
 #[test]
 fn pid_resources() {
     let h = cgroups::hierarchies::auto();
-    let h = Box::new(&*h);
-    let cg = Cgroup::new(h, String::from("pid_resources"));
+    let cg = Cgroup::new(&*h, String::from("pid_resources"));
     {
         let res = Resources {
             pid: PidResources {


### PR DESCRIPTION
- Refactor
    - Use Option as resource fields, remove the update switch: update_values
    - Make Cgroup can be stored in struct(remove lifetime, impl Clone, Default, Debug for Cgroup )
- New features
    - Expose deletion error
    - Support customized attributes for CpuController and MemController(for customized kernels)
    - Detect subsystems and get root from /proc/self/mountinfo
    - Support set notify_on_release & release_agent
- Fix bugs
- Update tests