### PR TITLE
optimize and refactor: read_to_string and read_i[u]64_from

### DIFF
--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -8,13 +8,13 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/blkio-controller.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::{read_string_from, read_u64_from};
 use crate::{
     BlkIoResources, ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem,
 };
@@ -398,25 +398,6 @@ impl<'a> From<&'a Subsystem> for &'a BlkIoController {
                 }
             }
         }
-    }
-}
-
-fn read_string_from(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
-use crate::{parse_max_value, read_i64_from};
+use crate::{parse_max_value, read_i64_from, read_u64_from};
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, CustomizedAttribute,
@@ -107,17 +107,6 @@ impl<'a> From<&'a Subsystem> for &'a CpuController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -7,13 +7,13 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/cpuacct.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/cpuacct.txt)
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::{read_string_from, read_u64_from};
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
 /// A controller that allows controlling the `cpuacct` subsystem of a Cgroup.
@@ -94,26 +94,6 @@ impl<'a> From<&'a Subsystem> for &'a CpuAcctController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    let res = file.read_to_string(&mut string);
-    match res {
-        Ok(_) => match string.trim().parse() {
-            Ok(e) => Ok(e),
-            Err(e) => Err(Error::with_cause(ParseError, e)),
-        },
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
-    }
-}
-
-fn read_string_from(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -10,13 +10,13 @@
 //!  [Documentation/cgroup-v1/cpusets.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/cpusets.txt)
 
 use log::*;
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::{read_string_from, read_u64_from};
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, CpuResources, Resources, Subsystem,
 };
@@ -201,25 +201,6 @@ impl<'a> From<&'a Subsystem> for &'a CpuSetController {
                 }
             }
         }
-    }
-}
-
-fn read_string_from(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/hugetlb.rs
+++ b/src/hugetlb.rs
@@ -8,13 +8,12 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/hugetlb.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/hugetlb.txt)
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
-use crate::flat_keyed_to_vec;
+use crate::{flat_keyed_to_vec, read_u64_from};
 
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, HugePageResources, Resources, Subsystem,
@@ -83,17 +82,6 @@ impl<'a> From<&'a Subsystem> for &'a HugeTlbController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 macro_rules! update_and_test {
     ($self: ident, $set_func:ident, $value:expr, $get_func:ident) => {
@@ -832,14 +833,35 @@ pub fn nested_keyed_to_hashmap(mut file: File) -> Result<HashMap<String, HashMap
     Ok(h)
 }
 
-/// read and parse an i64 data
-fn read_i64_from(mut file: File) -> Result<i64> {
+fn read_from<T>(mut file: File) -> Result<T>
+where
+    T: FromStr,
+    <T as FromStr>::Err: 'static + Send + Sync + std::error::Error,
+{
     let mut string = String::new();
     match file.read_to_string(&mut string) {
         Ok(_) => string
             .trim()
-            .parse()
+            .parse::<T>()
             .map_err(|e| Error::with_cause(ParseError, e)),
         Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
+}
+
+fn read_string_from(mut file: File) -> Result<String> {
+    let mut string = String::new();
+    match file.read_to_string(&mut string) {
+        Ok(_) => Ok(string.trim().to_string()),
+        Err(e) => Err(Error::with_cause(ReadFailed, e)),
+    }
+}
+
+/// read and parse an u64 data
+fn read_u64_from(file: File) -> Result<u64> {
+    read_from::<u64>(file)
+}
+
+/// read and parse an i64 data
+fn read_i64_from(file: File) -> Result<i64> {
+    read_from::<i64>(file)
 }

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -9,15 +9,14 @@
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/memory.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt)
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 use std::sync::mpsc::Receiver;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 use crate::events;
-use crate::read_i64_from;
+use crate::{read_i64_from, read_string_from, read_u64_from};
 
 use crate::flat_keyed_to_hashmap;
 
@@ -867,25 +866,6 @@ impl<'a> From<&'a Subsystem> for &'a MemController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
-    }
-}
-
-fn read_string_from(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/net_cls.rs
+++ b/src/net_cls.rs
@@ -7,13 +7,13 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/net_cls.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/net_cls.txt)
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::read_u64_from;
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
@@ -71,17 +71,6 @@ impl<'a> From<&'a Subsystem> for &'a NetClsController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/net_prio.rs
+++ b/src/net_prio.rs
@@ -8,13 +8,13 @@
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/net_prio.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/net_prio.txt)
 use std::collections::HashMap;
-use std::fs::File;
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::read_u64_from;
 use crate::{
     ControllIdentifier, ControllerInternal, Controllers, NetworkResources, Resources, Subsystem,
 };
@@ -74,17 +74,6 @@ impl<'a> From<&'a Subsystem> for &'a NetPrioController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/pid.rs
+++ b/src/pid.rs
@@ -8,13 +8,13 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroups-v1/pids.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/pids.txt)
-use std::fs::File;
 use std::io::{Read, Write};
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::read_u64_from;
 use crate::{
     parse_max_value, ControllIdentifier, ControllerInternal, Controllers, MaxValue, PidResources,
     Resources, Subsystem,
@@ -86,17 +86,6 @@ impl<'a> From<&'a Subsystem> for &'a PidController {
                 }
             }
         }
-    }
-}
-
-fn read_u64_from(mut file: File) -> Result<u64> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => string
-            .trim()
-            .parse()
-            .map_err(|e| Error::with_cause(ParseError, e)),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 

--- a/src/rdma.rs
+++ b/src/rdma.rs
@@ -7,13 +7,13 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/rdma.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/rdma.txt)
-use std::fs::File;
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::PathBuf;
 
 use crate::error::ErrorKind::*;
 use crate::error::*;
 
+use crate::read_string_from;
 use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
 
 /// A controller that allows controlling the `rdma` subsystem of a Cgroup.
@@ -63,14 +63,6 @@ impl<'a> From<&'a Subsystem> for &'a RdmaController {
                 }
             }
         }
-    }
-}
-
-fn read_string_from(mut file: File) -> Result<String> {
-    let mut string = String::new();
-    match file.read_to_string(&mut string) {
-        Ok(_) => Ok(string.trim().to_string()),
-        Err(e) => Err(Error::with_cause(ReadFailed, e)),
     }
 }
 


### PR DESCRIPTION
 There's so many Duplicated read_string_from method in different subsystem's implementation, and so as read_u64_from/read_i64_from methods.
 (1) Move the read_string_from method into `lib.rs`, called by each subsystem implementation as needed.
 (2) Refactor read_u[i]64_from method with the help Rust Generic function `read_from` and wrapped by read_u64_from or read_i64_from.

fix: #20

Signed-off-by: LiYa'nan <oliverliyn@gmail.com>