### PR TITLE
Add field homepage and readme for Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT OR Apache-2.0"
 version = "0.2.2"
 authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>", "Levente Kurusa <lkurusa@acm.org>", "Sam Wilson <tecywiz121@hotmail.com>"]
 edition = "2018"
+homepage = "https://github.com/kata-containers/cgroups-rs"
+readme = "README.md"
 
 [dependencies]
 log = "0.4"


### PR DESCRIPTION
Display readme on the crate's page.

Signed-off-by: Tim Zhang <tim@hyper.sh>