### PR TITLE
github: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,17 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'bug, needs-review'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement-request.md
@@ -1,0 +1,20 @@
+---
+name: Enhancement request
+about: Suggest an improvement to an existing feature
+title: ''
+labels: enhancement, needs-review
+assignees: ''
+
+---
+
+**Which feature do you think can be improved?**
+
+Specify the feature you think could be made better.
+
+**How can it be improved?**
+
+Describe how specifically you think it could be improved.
+
+**Additional Information**
+
+Anything else to add?

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'feature, needs-review'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
cgroups-rs should not use the repository default issue templates.
Let's add a private version to override the default ones.

Fixes: #29
Signed-off-by: Peng Tao <bergwolf@hyper.sh>