### PR TITLE
cgroup: get the mount info without procinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ log = "0.4"
 regex = "1.1"
 nix = "0.18.0"
 libc = "0.2"
-procinfo = "0.4.2"
 
 [dev-dependencies]
 libc = "0.2.76"


### PR DESCRIPTION
The procinfo library gets all the mount info,
but we don't need all the mount info.

Signed-off-by: quanweiZhou <quanweiZhou@linux.alibaba.com>