### PR TITLE
Update nix to 0.20.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 log = "0.4"
 regex = "1.1"
-nix = "0.18.0"
+nix = "0.20.0"
 libc = "0.2"
 
 [dev-dependencies]

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -62,7 +62,7 @@ fn test_pid_events_is_not_zero() {
         let before = pids.get_pid_events();
         let before = before.unwrap();
 
-        match fork() {
+        match unsafe { fork() } {
             Ok(ForkResult::Parent { child, .. }) => {
                 // move the process into the control group
                 let _ = pids.add_task(&(pid_t::from(child) as u64).into());
@@ -89,7 +89,7 @@ fn test_pid_events_is_not_zero() {
             Ok(ForkResult::Child) => loop {
                 let pids_max = pids.get_pid_max();
                 if pids_max.is_ok() && pids_max.unwrap() == MaxValue::Value(1) {
-                    if let Err(_) = fork() {
+                    if let Err(_) = unsafe { fork() } {
                         unsafe { libc::exit(0) };
                     } else {
                         unsafe { libc::exit(1) };


### PR DESCRIPTION
to pull in https://github.com/nix-rust/nix/pull/1372 and get statfs MAGIC constants on s390x. Additionally, fork() calls in tests now have to be marked unsafe.

Fixes: #37

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>