### PR TITLE
std::process::Command extension trait to allow adding process to a cgroup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ Cargo.lock
 /target
 **/*.rs.bk
 Cargo.lock
+
+# IDEs
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4"
-regex = "1.1"
-nix = "0.20.0"
+regex = "1.5"
+nix = "0.21.0"
 libc = "0.2"
 
 [dev-dependencies]
-libc = "0.2.76"
+libc = "0.2.95"

--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -307,6 +307,10 @@ impl Cgroup {
         v.dedup();
         v
     }
+
+    pub fn path(&self) -> &str {
+        &self.path
+    }
 }
 
 pub const UNIFIED_MOUNTPOINT: &str = "/sys/fs/cgroup";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,8 @@ pub mod perf_event;
 pub mod pid;
 pub mod rdma;
 pub mod systemd;
+pub mod process_ext;
+
 
 use crate::blkio::BlkIoController;
 use crate::cpu::CpuController;

--- a/src/process_ext.rs
+++ b/src/process_ext.rs
@@ -1,0 +1,63 @@
+use std::fs::write;
+use std::os::unix::process::CommandExt;
+use std::path::PathBuf;
+use std::process;
+use std::process::Command;
+
+use crate::Cgroup;
+
+/// Extensions to default `std::process::Command` capabilities.
+pub trait CgroupsCommandExt {
+    /// Sets cgroups for the process to be put into before execution of that process starts.
+    ///
+    /// # Examples
+    /// ```
+    /// use std::process::Command;
+    /// use cgroups_rs::{Cgroup, CgroupPid};
+    /// use cgroups_rs::cgroup_builder::CgroupBuilder;
+    /// use cgroups_rs::MaxValue::Value;
+    /// use cgroups_rs::process_ext::CgroupsCommandExt;
+    /// use std::cell::Ref;
+    ///
+    /// let mut process = Command::new("ls");
+    ///
+    /// let hierarchy = cgroups_rs::hierarchies::auto();
+    /// let cgroup_name = "test";
+    /// let cg: Cgroup = CgroupBuilder::new(cgroup_name)
+    ///         .cpu()
+    ///         .cpus("1".to_owned())
+    ///         .shares(100)
+    ///         .done()
+    ///         .build(hierarchy);
+    /// let mut child = process.cgroups(&[&cg])
+    ///         .spawn()
+    ///         .expect("The 'ls' process did not spawn.");
+    /// let child_pid = CgroupPid::from(&child);
+    /// println!("{:?}", child.wait_with_output().expect("Expected 'ls' to provide an output'"));
+    /// cg.remove_task(child_pid);
+    /// cg.delete();
+    ///
+    /// ```
+    fn cgroups(&mut self, cgroups: &[&Cgroup]) -> &mut Self;
+}
+
+impl CgroupsCommandExt for Command {
+    ///Adds PID of `self` to given cgroups before the process is started using unix-specific
+    /// `pre_exec` functionality. First, the PID is written into
+    /// Inspired by the `cgroups-fs` crate.
+    fn cgroups(&mut self, cgroups: &[&Cgroup]) -> &mut Self {
+        let tasks_paths = cgroups
+            .iter()
+            .map(|cgroup| PathBuf::from(cgroup.path()))
+            .collect::<Vec<PathBuf>>();
+        unsafe {
+            self.pre_exec(move || {
+                let pid = process::id().to_string();
+                for tasks_path in &tasks_paths {
+                    write(tasks_path, &pid)?;
+                }
+                Ok(())
+            })
+        }
+    }
+}


### PR DESCRIPTION
Inspired by a functionality already present in the [cgroups-fs](https://docs.rs/cgroups-fs/1.1.2/cgroups_fs/trait.CgroupsCommandExt.html) crate.

Uses the `pre_exec` function to write the PID of the process into the given cgroups. Before the process is spawned.