### PR TITLE
freezer: fix the issue of missing trim the str

### DIFF
--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -130,7 +130,7 @@ impl FreezerController {
             let mut s = String::new();
             let res = file.read_to_string(&mut s);
             match res {
-                Ok(_) => match s.as_ref() {
+                Ok(_) => match s.trim() {
                     "FROZEN" => Ok(FreezerState::Frozen),
                     "THAWED" => Ok(FreezerState::Thawed),
                     "1" => Ok(FreezerState::Frozen),


### PR DESCRIPTION
When reading from the freezer file, it should trim it
first, and the string may container an '\n'.

Fixes: #48

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>