### PR TITLE
Add Serialize/Deserialize to resource and stat types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ log = "0.4"
 regex = "1.1"
 nix = "0.20.0"
 libc = "0.2"
+serde = { version = "1.0", features = ["derive"], optional = true }
 
 [dev-dependencies]
 libc = "0.2.76"
+
+[features]
+default = []

--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -31,6 +31,7 @@ pub struct BlkIoController {
 }
 
 #[derive(Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Per-device information
 pub struct BlkIoData {
     /// The major number of the device.
@@ -42,6 +43,7 @@ pub struct BlkIoData {
 }
 
 #[derive(Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Per-device activity from the control group.
 pub struct IoService {
     /// The major number of the device.
@@ -61,6 +63,7 @@ pub struct IoService {
 }
 
 #[derive(Eq, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Per-device activity from the control group.
 /// Only for cgroup v2
 pub struct IoStat {
@@ -203,6 +206,7 @@ fn parse_blkio_data(s: String) -> Result<Vec<BlkIoData>> {
 /// Current state and statistics about how throttled are the block devices when accessed from the
 /// controller's control group.
 #[derive(Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlkIoThrottle {
     /// Statistics about the bytes transferred between the block devices by the tasks in this
     /// control group.
@@ -238,6 +242,7 @@ pub struct BlkIoThrottle {
 
 /// Statistics and state of the block devices.
 #[derive(Default, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlkIo {
     /// The number of BIOS requests merged into I/O requests by the control group's tasks.
     pub io_merged: Vec<IoService>,

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -36,6 +36,7 @@ pub struct CpuController {
 
 /// The current state of the control group and its processes.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Cpu {
     /// Reports CPU time statistics.
     ///

--- a/src/cpuacct.rs
+++ b/src/cpuacct.rs
@@ -27,6 +27,7 @@ pub struct CpuAcctController {
 }
 
 /// Represents the statistics retrieved from the control group.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CpuAcct {
     /// Divides the time used by the tasks into `user` time and `system` time.
     pub stat: String,

--- a/src/cpuset.rs
+++ b/src/cpuset.rs
@@ -33,6 +33,7 @@ pub struct CpuSetController {
 }
 
 /// The current state of the `cpuset` controller for this control group.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CpuSet {
     /// If true, no other control groups can share the CPUs listed in the `cpus` field.
     pub cpu_exclusive: bool,

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -32,6 +32,11 @@ pub struct DevicesController {
 
 /// An enum holding the different types of devices that can be manipulated using this controller.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum DeviceType {
     /// The rule applies to all devices.
     All,
@@ -71,6 +76,11 @@ impl DeviceType {
 
 /// An enum with the permissions that can be allowed/denied to the control group.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "snake_case")
+)]
 pub enum DevicePermissions {
     /// Permission to read from the device.
     Read,

--- a/src/freezer.rs
+++ b/src/freezer.rs
@@ -32,6 +32,7 @@ pub struct FreezerController {
 }
 
 /// The current state of the control group
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FreezerState {
     /// The processes in the control group are _not_ frozen.
     Thawed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,7 @@ pub trait Hierarchy: std::fmt::Debug + Send + Sync {
 
 /// Resource limits for the memory subsystem.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryResources {
     /// How much memory (in bytes) can the kernel consume.
     pub kernel_memory_limit: Option<i64>,
@@ -446,13 +447,15 @@ pub struct MemoryResources {
     /// # Usage:
     /// ```
     /// let resource = &mut cgroups_rs::Resources::default();
-    /// resource.memory.attrs.insert("memory.numa_balancing", "true".to_string());
+    /// resource.memory.attrs.insert("memory.numa_balancing".to_string(), "true".to_string());
     /// // apply here
-    pub attrs: std::collections::HashMap<&'static str, String>,
+    /// ```
+    pub attrs: HashMap<String, String>,
 }
 
 /// Resources limits on the number of processes.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct PidResources {
     /// The maximum number of processes that can exist in the control group.
     ///
@@ -464,6 +467,7 @@ pub struct PidResources {
 
 /// Resources limits about how the tasks can use the CPU.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct CpuResources {
     // cpuset
     /// A comma-separated list of CPU IDs where the task in the control group can run. Dashes
@@ -488,14 +492,15 @@ pub struct CpuResources {
     /// # Usage:
     /// ```
     /// let resource = &mut cgroups_rs::Resources::default();
-    /// resource.cpu.attrs.insert("cpu.cfs_init_buffer_us", "10".to_string());
+    /// resource.cpu.attrs.insert("cpu.cfs_init_buffer_us".to_string(), "10".to_string());
     /// // apply here
     /// ```
-    pub attrs: std::collections::HashMap<&'static str, String>,
+    pub attrs: HashMap<String, String>,
 }
 
 /// A device resource that can be allowed or denied access to.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceResource {
     /// If true, access to the device is allowed, otherwise it's denied.
     pub allow: bool,
@@ -511,6 +516,7 @@ pub struct DeviceResource {
 
 /// Limit the usage of devices for the control group's tasks.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeviceResources {
     /// For each device in the list, the limits in the structure are applied.
     pub devices: Vec<DeviceResource>,
@@ -518,6 +524,7 @@ pub struct DeviceResources {
 
 /// Assigned priority for a network device.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NetworkPriority {
     /// The name (as visible in `ifconfig`) of the interface.
     pub name: String,
@@ -528,6 +535,7 @@ pub struct NetworkPriority {
 /// Collections of limits and tags that can be imposed on packets emitted by the tasks in the
 /// control group.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NetworkResources {
     /// The networking class identifier to attach to the packets.
     ///
@@ -539,6 +547,7 @@ pub struct NetworkResources {
 
 /// A hugepage type and its consumption limit for the control group.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HugePageResource {
     /// The size of the hugepage, i.e. `2MB`, `1GB`, etc.
     pub size: String,
@@ -549,6 +558,7 @@ pub struct HugePageResource {
 
 /// Provides the ability to set consumption limit on each type of hugepages.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HugePageResources {
     /// Set a limit of consumption for each hugepages type.
     pub limits: Vec<HugePageResource>,
@@ -556,6 +566,7 @@ pub struct HugePageResources {
 
 /// Weight for a particular block device.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlkIoDeviceResource {
     /// The major number of the device.
     pub major: u64,
@@ -569,6 +580,7 @@ pub struct BlkIoDeviceResource {
 
 /// Provides the ability to throttle a device (both byte/sec, and IO op/s)
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlkIoDeviceThrottleResource {
     /// The major number of the device.
     pub major: u64,
@@ -580,6 +592,7 @@ pub struct BlkIoDeviceThrottleResource {
 
 /// General block I/O resource limits.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct BlkIoResources {
     /// The weight of the control group against descendant nodes.
     pub weight: Option<u16>,
@@ -599,6 +612,7 @@ pub struct BlkIoResources {
 
 /// The resource limits and constraints that will be set on the control group.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Resources {
     /// Memory usage related limits.
     pub memory: MemoryResources,
@@ -724,6 +738,7 @@ impl Subsystem {
 
 /// The values for `memory.hight` or `pids.max`
 #[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum MaxValue {
     /// This value is returned when the text is `"max"`.
     Max,

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -38,6 +38,7 @@ pub struct MemController {
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SetMemory {
     pub low: Option<MaxValue>,
     pub high: Option<MaxValue>,
@@ -47,6 +48,7 @@ pub struct SetMemory {
 
 /// Controls statistics and controls about the OOM killer operating in this control group.
 #[derive(Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OomControl {
     /// If true, the OOM killer has been disabled for the tasks in this control group.
     pub oom_kill_disable: bool,
@@ -87,6 +89,7 @@ fn parse_oom_control(s: String) -> Result<OomControl> {
 
 /// Contains statistics about the NUMA locality of the control group's tasks.
 #[derive(Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NumaStat {
     /// Total amount of pages used by the control group.
     pub total_pages: u64,
@@ -302,6 +305,7 @@ fn parse_numa_stat(s: String) -> Result<NumaStat> {
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemoryStat {
     pub cache: u64,
     pub rss: u64,
@@ -403,6 +407,7 @@ fn parse_memory_stat(s: String) -> Result<MemoryStat> {
 /// Contains statistics about the current usage of memory and swap (together, not seperately) by
 /// the control group's tasks.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MemSwap {
     /// How many times the limit has been hit.
     pub fail_cnt: u64,
@@ -417,6 +422,7 @@ pub struct MemSwap {
 /// State of and statistics gathered by the kernel about the memory usage of the control group's
 /// tasks.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Memory {
     /// How many times the limit has been hit.
     pub fail_cnt: u64,
@@ -461,6 +467,7 @@ pub struct Memory {
 /// The current state of and gathered statistics about the kernel's memory usage for TCP-related
 /// data structures.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Tcp {
     /// How many times the limit has been hit.
     pub fail_cnt: u64,
@@ -479,6 +486,7 @@ pub struct Tcp {
 /// these tasks if it would think that the limits here would be violated. It's important to note
 /// that interrupts in particular might not be able to enforce these limits.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Kmem {
     /// How many times the limit has been hit.
     pub fail_cnt: u64,


### PR DESCRIPTION
Add feature "serde" that derives all resource and statistics types from Serialize and Deserialize. The feature is turned off by default.

Fixes #54
Fixes #55
Fixes #56 