### PR TITLE
deps: update nix to 0.20.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 log = "0.4"
 regex = "1.1"
-nix = "0.20.0"
+nix = "0.20.2"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -51,7 +51,7 @@ fn test_cpuset_set_cpus() {
         let cpus = fs::read_to_string("/sys/fs/cgroup/cpuset.cpus.effective").unwrap_or_default();
         let cpus = cpus.trim();
         if !cpus.is_empty() {
-            let r = cpuset.set_cpus(&cpus);
+            let r = cpuset.set_cpus(cpus);
             assert!(r.is_ok());
             let set = cpuset.cpuset();
             assert_eq!(1, set.cpus.len());


### PR DESCRIPTION
Enforces use of a version of nix which contains a patch for
RUSTSEC-2021-0119.

Fixes #58

Signed-off-by: Jon Magnuson <jon.magnuson@gmail.com>