### PR TITLE
fix: support FreezerController in cgroups v2

### DIFF
--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -202,7 +202,12 @@ impl Hierarchy for V2 {
         let mut subs = vec![];
 
         let controllers = ret.unwrap().trim().to_string();
-        let controller_list: Vec<&str> = controllers.split(' ').collect();
+        let mut controller_list: Vec<&str> = controllers.split(' ').collect();
+
+        // The freezer functionality is present in V2, but not as a controller,
+        // but apparently as a core functionality. FreezerController supports
+        // that, but we must explicitly fake the controller here.
+        controller_list.push("freezer");
 
         for s in controller_list {
             match s {


### PR DESCRIPTION
`FreezerController` implements the functionality for cgroups v2, but the freezer subsystem is not instantiated, because there is no "freezer" controller in `cgroup.controllers` (the functionality is supported via `cgroup.freeze`, which is not part of any controller).

This PR forces the "freezer" controller for cgroups v2.