### PR TITLE
fix: read task hang when the cgroup dir removed after open

### DIFF
--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -87,7 +87,7 @@ fn mountinfo_file(file: &mut File) -> Vec<Mountinfo> {
                     }
                 }
             }
-            Err(_) => continue,
+            Err(_) => break,
         }
     }
     r

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,9 +365,14 @@ where
             .map(|file| {
                 let bf = BufReader::new(file);
                 let mut v = Vec::new();
-                for line in bf.lines().flatten() {
-                    let n = line.trim().parse().unwrap_or(0u64);
-                    v.push(n);
+                for line in bf.lines() {
+                    match line {
+                        Ok(line) => {
+                            let n = line.trim().parse().unwrap_or(0u64);
+                            v.push(n);
+                        }
+                        Err(_) => break,
+                    }
                 }
                 v.into_iter().map(CgroupPid::from).collect()
             })


### PR DESCRIPTION
Fixes #62
Signed-off-by: quanweiZhou <quanweiZhou@linux.alibaba.com>