### PR TITLE
action: Lock rust version and fix commit-body checker

### DIFF
--- a/.github/workflows/bvt.yaml
+++ b/.github/workflows/bvt.yaml
@@ -1,20 +1,22 @@
 name: BVT
 on: [pull_request]
+env:
+  RUST_VERSION: 1.52
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Build
-        run: make debug
+      - uses: actions/checkout@v2
+      - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
+      - run: make debug
 
   fmt:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
       - run: rustup component add rustfmt
       - run: make fmt
   clippy:
@@ -22,6 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
       - run: rustup component add clippy
       - run: make clippy
   test:
@@ -29,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
       - run: make test
 
 

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -48,6 +48,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^.+(\n.{0,72})*$|^.+\n\s*[^a-zA-Z\s\n]|^.+\n\S+$'
+        pattern: '^.+(\n([a-zA-Z].{0,149}|[^a-zA-Z\n].*|Signed-off-by:.*|))+$'
         error: 'Body line too long (max 72)'
         post_error: ${{ env.error_msg }}


### PR DESCRIPTION
commit bf5af7b1951438e807ef5eebed01bc5161b7a866 (HEAD -> action-lock-rust-version, origin/action-lock-rust-version)
Author: Tim Zhang <tim@hyper.sh>
Date:   Wed Nov 10 19:30:12 2021 +0800

    action: fix the the body line checker
    
    the original regex can not handle pasted error message
    rightly. this commit will fix this.
    
    Signed-off-by: Tim Zhang <tim@hyper.sh>

commit 2e3719dbd5f0a31d55fabc68bc0b49843b71c076
Author: Tim Zhang <tim@hyper.sh>
Date:   Wed Nov 10 16:28:39 2021 +0800

    action: Lock rust version to 1.52
    
    Got the following error in the clippy:
    error: this expression borrows a reference (`&str`) that is immediately dereferenced by the compiler
      --> tests/cpuset.rs:54:37
       |
    54 |             let r = cpuset.set_cpus(&cpus);
       |                                     ^^^^^ help: change this to: `cpus`
       |
       = note: `-D clippy::needless-borrow` implied by `-D warnings`
       = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    
    But we did not touch the code, just becuase the clippy rules was updated
    follow the rust update.
    
    To avoid this problem we lock the rust version in CI and make it
    steady.
    
    Signed-off-by: Tim Zhang <tim@hyper.sh>