### PR TITLE
cargo: Update nix to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 [dependencies]
 log = "0.4"
 regex = "1.1"
-nix = "0.20.2"
+nix = "0.23.0"
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 


### PR DESCRIPTION
Update the `nix` crate to version `0.23.0` to resolve a dependency
issue related to making `cargo audit` run cleanly for the Kata
Containers agent.

See:

https://github.com/kata-containers/kata-containers/pull/3125

Fixes: #66.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>