### PR TITLE
clippy: Fix clippy version 0.1.60

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -295,7 +295,7 @@ fn parse_cfs_quota_and_period(mut file: File) -> Result<CfsQuotaAndPeriod> {
         return Err(Error::from_string(format!("invaild format: {}", content)));
     }
 
-    let quota = parse_max_value(&fields[0].to_string())?;
+    let quota = parse_max_value(fields[0])?;
     let period = fields[1]
         .parse::<u64>()
         .map_err(|e| Error::with_cause(ParseError, e))?;

--- a/src/events.rs
+++ b/src/events.rs
@@ -52,12 +52,11 @@ fn register_memory_event(
         eventfd(0, EfdFlags::EFD_CLOEXEC).map_err(|e| Error::with_cause(ReadFailed, e))?;
 
     let event_control_path = cg_dir.join("cgroup.event_control");
-    let data;
-    if arg.is_empty() {
-        data = format!("{} {}", eventfd, event_file.as_raw_fd());
+    let data = if arg.is_empty() {
+        format!("{} {}", eventfd, event_file.as_raw_fd())
     } else {
-        data = format!("{} {} {}", eventfd, event_file.as_raw_fd(), arg);
-    }
+        format!("{} {} {}", eventfd, event_file.as_raw_fd(), arg)
+    };
 
     // write to file and set mode to 0700(FIXME)
     fs::write(&event_control_path, data).map_err(|e| Error::with_cause(WriteFailed, e))?;

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -170,7 +170,7 @@ impl Hierarchy for V1 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        Cgroup::load(auto(), "".to_string())
+        Cgroup::load(auto(), "")
     }
 
     fn root(&self) -> PathBuf {
@@ -246,7 +246,7 @@ impl Hierarchy for V2 {
     }
 
     fn root_control_group(&self) -> Cgroup {
-        Cgroup::load(auto(), "".to_string())
+        Cgroup::load(auto(), "")
     }
 
     fn root(&self) -> PathBuf {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -771,7 +771,7 @@ impl fmt::Display for MaxValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             MaxValue::Max => write!(f, "max"),
-            MaxValue::Value(num) => write!(f, "{}", num.to_string()),
+            MaxValue::Value(num) => write!(f, "{}", num),
         }
     }
 }

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -17,7 +17,7 @@ use crate::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subs
 pub struct SystemdController {
     base: PathBuf,
     path: PathBuf,
-    v2: bool,
+    _v2: bool,
 }
 
 impl ControllerInternal for SystemdController {
@@ -66,7 +66,7 @@ impl SystemdController {
         Self {
             base: root.clone(),
             path: root,
-            v2,
+            _v2: v2,
         }
     }
 }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -137,11 +137,8 @@ pub fn test_hugepages_res_build() {
 
     {
         let c: &HugeTlbController = cg.controller_of().unwrap();
-        assert!(c.limit_in_bytes(&"2MB".to_string()).is_ok());
-        assert_eq!(
-            c.limit_in_bytes(&"2MB".to_string()).unwrap(),
-            4 * 2 * 1024 * 1024
-        );
+        assert!(c.limit_in_bytes("2MB").is_ok());
+        assert_eq!(c.limit_in_bytes("2MB").unwrap(), 4 * 2 * 1024 * 1024);
     }
     cg.delete().unwrap();
 }

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -40,5 +40,5 @@ fn test_hugetlb_sizes() {
 }
 
 fn assert_no_error(r: Result<u64>) {
-    assert!(!r.is_err())
+    assert!(r.is_ok())
 }

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -23,7 +23,7 @@ fn test_disable_oom_killer() {
         if !mem_controller.v2() {
             // disable oom killer
             let r = mem_controller.disable_oom_killer();
-            assert!(!r.is_err());
+            assert!(r.is_ok());
 
             // after disable
             let m = mem_controller.memory_stat();


### PR DESCRIPTION
Fix clippy lints from clippy 0.1.60 (7737e0b 2022-04-04).