### PR TITLE
memory: set_kmem_limit: ignore Unsupported error

### DIFF
--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -47,7 +47,8 @@ pub fn test_memory_res_build() {
     {
         let c: &MemController = cg.controller_of().unwrap();
         if !c.v2() {
-            assert_eq!(c.kmem_stat().limit_in_bytes, 128 * 1024 * 1024);
+            // Note: we don't tests the value of c.kmem_stat().limit_in_bytes because on Linux
+            // kernel >= 5.16 setting this value is unsupported.
             assert_eq!(c.memory_stat().swappiness, 70);
         }
         assert_eq!(c.memory_stat().limit_in_bytes, 1024 * 1024 * 1024);

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -34,6 +34,21 @@ fn test_disable_oom_killer() {
 }
 
 #[test]
+fn set_kmem_limit_v1() {
+    let h = cgroups_rs::hierarchies::auto();
+    if h.v2() {
+        return;
+    }
+
+    let cg = Cgroup::new(h, String::from("set_kmem_limit_v1"));
+    {
+        let mem_controller: &MemController = cg.controller_of().unwrap();
+        mem_controller.set_kmem_limit(1).unwrap();
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
 fn set_mem_v2() {
     let h = cgroups_rs::hierarchies::auto();
     if !h.v2() {


### PR DESCRIPTION
Setting (writing into) `memory.kmem.limit_in_bytes` is not supported in
Linux kernel >= 5.16 (see kernel commit 58056f77502: "memcg, kmem:
further deprecate kmem.limit_in_bytes"):
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=58056f77502

If the write call in `set_kmem_limit()` returns EOPNOTSUPP, log a
warning message but ignore the error (do nothing).

Add a unit-test for `set_kmem_limit` in cgroups v1.

Fix #81

Signed-off-by: Dov Murik <dov.murik1@il.ibm.com>