### PR TITLE
blkio: Add support for customized-attributes

### DIFF
--- a/src/blkio.rs
+++ b/src/blkio.rs
@@ -16,7 +16,8 @@ use crate::error::*;
 
 use crate::{read_string_from, read_u64_from};
 use crate::{
-    BlkIoResources, ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem,
+    BlkIoResources, ControllIdentifier, ControllerInternal, Controllers, CustomizedAttribute,
+    Resources, Subsystem,
 };
 
 /// A controller that allows controlling the `blkio` subsystem of a Cgroup.
@@ -377,6 +378,10 @@ impl ControllerInternal for BlkIoController {
         for dev in &res.throttle_write_iops_device {
             let _ = self.throttle_write_iops_for_device(dev.major, dev.minor, dev.rate);
         }
+
+        res.attrs.iter().for_each(|(k, v)| {
+            let _ = self.set(k, v);
+        });
 
         Ok(())
     }
@@ -771,6 +776,7 @@ impl BlkIoController {
     }
 }
 
+impl CustomizedAttribute for BlkIoController {}
 #[cfg(test)]
 mod test {
     use crate::blkio::{parse_blkio_data, BlkIoData};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -613,6 +613,15 @@ pub struct BlkIoResources {
     pub throttle_write_bps_device: Vec<BlkIoDeviceThrottleResource>,
     /// Throttled write IO operations per second can be provided for each device.
     pub throttle_write_iops_device: Vec<BlkIoDeviceThrottleResource>,
+
+    /// Customized key-value attributes
+    /// # Usage:
+    /// ```
+    /// let resource = &mut cgroups_rs::Resources::default();
+    /// resource.blkio.attrs.insert("io.cost.weight".to_string(), "10".to_string());
+    /// // apply here
+    /// ```
+    pub attrs: HashMap<String, String>,
 }
 
 /// The resource limits and constraints that will be set on the control group.


### PR DESCRIPTION
Customized attributes are useful for customized kernels.

It's a new way to achieve the closed pr #85 's aim.

Signed-off-by: Tim Zhang <tim@hyper.sh>