### PR TITLE
cgroup: support to set threaded mode in cgroup v2

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -51,6 +51,18 @@ pub enum ErrorKind {
     #[error("invalid bytes size")]
     InvalidBytesSize,
 
+    /// The specified controller is not in the list of supported controllers.
+    #[error("specified controller is not in the list of supported controllers")]
+    SpecifiedControllers,
+
+    /// Using method in wrong cgroup version.
+    #[error("using method in wrong cgroup version")]
+    CgroupVersion,
+
+    /// Subsystems is empty.
+    #[error("subsystems is empty")]
+    SubsystemsEmpty,
+
     /// An unknown error has occured.
     #[error("an unknown error")]
     Other,

--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -12,7 +12,7 @@
 use std::fs;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::blkio::BlkIoController;
 use crate::cpu::CpuController;
@@ -173,6 +173,12 @@ impl Hierarchy for V1 {
         Cgroup::load(auto(), "")
     }
 
+    fn parent_control_group(&self, path: &str) -> Cgroup {
+        let path = Path::new(path);
+        let parent_path = path.parent().unwrap().to_string_lossy().to_string();
+        Cgroup::load(auto(), &parent_path)
+    }
+
     fn root(&self) -> PathBuf {
         self.mountinfo
             .iter()
@@ -247,6 +253,12 @@ impl Hierarchy for V2 {
 
     fn root_control_group(&self) -> Cgroup {
         Cgroup::load(auto(), "")
+    }
+
+    fn parent_control_group(&self, path: &str) -> Cgroup {
+        let path = Path::new(path);
+        let parent_path = path.parent().unwrap().to_string_lossy().to_string();
+        Cgroup::load(auto(), &parent_path)
     }
 
     fn root(&self) -> PathBuf {

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -22,7 +22,8 @@ pub fn test_cpu_res_build() {
         .cpu()
         .shares(85)
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let cpu: &CpuController = cg.controller_of().unwrap();
@@ -42,7 +43,8 @@ pub fn test_memory_res_build() {
         .swappiness(70)
         .memory_hard_limit(1024 * 1024 * 1024)
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let c: &MemController = cg.controller_of().unwrap();
@@ -64,7 +66,8 @@ pub fn test_pid_res_build() {
         .pid()
         .maximum_number_of_processes(MaxValue::Value(123))
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let c: &PidController = cg.controller_of().unwrap();
@@ -83,7 +86,8 @@ pub fn test_devices_res_build() {
         .devices()
         .device(1, 6, DeviceType::Char, true, vec![DevicePermissions::Read])
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let c: &DevicesController = cg.controller_of().unwrap();
@@ -113,7 +117,8 @@ pub fn test_network_res_build() {
         .network()
         .class_id(1337)
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let c: &NetClsController = cg.controller_of().unwrap();
@@ -134,7 +139,8 @@ pub fn test_hugepages_res_build() {
         .hugepages()
         .limit("2MB".to_string(), 4 * 2 * 1024 * 1024)
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let c: &HugeTlbController = cg.controller_of().unwrap();
@@ -152,7 +158,8 @@ pub fn test_blkio_res_build() {
         .blkio()
         .weight(100)
         .done()
-        .build(h);
+        .build(h)
+        .unwrap();
 
     {
         let c: &BlkIoController = cg.controller_of().unwrap();

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -10,7 +10,7 @@ use cgroups_rs::Cgroup;
 #[test]
 fn test_cfs_quota_and_periods() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_cfs_quota_and_periods"));
+    let cg = Cgroup::new(h, String::from("test_cfs_quota_and_periods")).unwrap();
 
     let cpu_controller: &CpuController = cg.controller_of().unwrap();
 

--- a/tests/cpuset.rs
+++ b/tests/cpuset.rs
@@ -13,7 +13,7 @@ use std::fs;
 #[test]
 fn test_cpuset_memory_pressure_root_cg() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_cpuset_memory_pressure_root_cg"));
+    let cg = Cgroup::new(h, String::from("test_cpuset_memory_pressure_root_cg")).unwrap();
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
@@ -27,7 +27,7 @@ fn test_cpuset_memory_pressure_root_cg() {
 #[test]
 fn test_cpuset_set_cpus() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus"));
+    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus")).unwrap();
     {
         let cpuset: &CpuSetController = cg.controller_of().unwrap();
 
@@ -64,7 +64,7 @@ fn test_cpuset_set_cpus() {
 #[test]
 fn test_cpuset_set_cpus_add_task() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus_add_task/sub-dir"));
+    let cg = Cgroup::new(h, String::from("test_cpuset_set_cpus_add_task/sub-dir")).unwrap();
 
     let cpuset: &CpuSetController = cg.controller_of().unwrap();
     let set = cpuset.cpuset();
@@ -77,13 +77,13 @@ fn test_cpuset_set_cpus_add_task() {
 
     // Add a task to the control group.
     let pid_i = libc::pid_t::from(nix::unistd::getpid()) as u64;
-    let _ = cg.add_task(CgroupPid::from(pid_i));
+    let _ = cg.add_task_by_tgid(CgroupPid::from(pid_i));
     let tasks = cg.tasks();
     assert!(!tasks.is_empty());
     println!("tasks after added: {:?}", tasks);
 
     // remove task
-    cg.remove_task(CgroupPid::from(pid_i));
+    cg.remove_task_by_tgid(CgroupPid::from(pid_i)).unwrap();
     let tasks = cg.tasks();
     println!("tasks after deleted: {:?}", tasks);
     assert_eq!(0, tasks.len());

--- a/tests/devices.rs
+++ b/tests/devices.rs
@@ -17,7 +17,7 @@ fn test_devices_parsing() {
     }
 
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_devices_parsing"));
+    let cg = Cgroup::new(h, String::from("test_devices_parsing")).unwrap();
     {
         let devices: &DevicesController = cg.controller_of().unwrap();
 

--- a/tests/hugetlb.rs
+++ b/tests/hugetlb.rs
@@ -17,7 +17,7 @@ fn test_hugetlb_sizes() {
     }
 
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_hugetlb_sizes"));
+    let cg = Cgroup::new(h, String::from("test_hugetlb_sizes")).unwrap();
     {
         let hugetlb_controller: &HugeTlbController = cg.controller_of().unwrap();
         let _ = hugetlb_controller.get_sizes();

--- a/tests/memory.rs
+++ b/tests/memory.rs
@@ -11,7 +11,7 @@ use cgroups_rs::{Cgroup, MaxValue};
 #[test]
 fn test_disable_oom_killer() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_disable_oom_killer"));
+    let cg = Cgroup::new(h, String::from("test_disable_oom_killer")).unwrap();
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 
@@ -40,7 +40,7 @@ fn set_kmem_limit_v1() {
         return;
     }
 
-    let cg = Cgroup::new(h, String::from("set_kmem_limit_v1"));
+    let cg = Cgroup::new(h, String::from("set_kmem_limit_v1")).unwrap();
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
         mem_controller.set_kmem_limit(1).unwrap();
@@ -55,7 +55,7 @@ fn set_mem_v2() {
         return;
     }
 
-    let cg = Cgroup::new(h, String::from("set_mem_v2"));
+    let cg = Cgroup::new(h, String::from("set_mem_v2")).unwrap();
     {
         let mem_controller: &MemController = cg.controller_of().unwrap();
 

--- a/tests/pids.rs
+++ b/tests/pids.rs
@@ -17,7 +17,7 @@ use libc::pid_t;
 #[test]
 fn create_and_delete_cgroup() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("create_and_delete_cgroup"));
+    let cg = Cgroup::new(h, String::from("create_and_delete_cgroup")).unwrap();
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         pidcontroller.set_pid_max(MaxValue::Value(1337)).unwrap();
@@ -31,7 +31,7 @@ fn create_and_delete_cgroup() {
 #[test]
 fn test_pids_current_is_zero() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_pids_current_is_zero"));
+    let cg = Cgroup::new(h, String::from("test_pids_current_is_zero")).unwrap();
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let current = pidcontroller.get_pid_current();
@@ -43,7 +43,7 @@ fn test_pids_current_is_zero() {
 #[test]
 fn test_pids_events_is_zero() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_pids_events_is_zero"));
+    let cg = Cgroup::new(h, String::from("test_pids_events_is_zero")).unwrap();
     {
         let pidcontroller: &PidController = cg.controller_of().unwrap();
         let events = pidcontroller.get_pid_events();
@@ -56,7 +56,7 @@ fn test_pids_events_is_zero() {
 #[test]
 fn test_pid_events_is_not_zero() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("test_pid_events_is_not_zero"));
+    let cg = Cgroup::new(h, String::from("test_pid_events_is_not_zero")).unwrap();
     {
         let pids: &PidController = cg.controller_of().unwrap();
         let before = pids.get_pid_events();
@@ -65,7 +65,7 @@ fn test_pid_events_is_not_zero() {
         match unsafe { fork() } {
             Ok(ForkResult::Parent { child, .. }) => {
                 // move the process into the control group
-                let _ = pids.add_task(&(pid_t::from(child) as u64).into());
+                let _ = pids.add_task_by_tgid(&(pid_t::from(child) as u64).into());
 
                 println!("added task to cg: {:?}", child);
 

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -11,7 +11,7 @@ use cgroups_rs::{Cgroup, MaxValue, PidResources, Resources};
 #[test]
 fn pid_resources() {
     let h = cgroups_rs::hierarchies::auto();
-    let cg = Cgroup::new(h, String::from("pid_resources"));
+    let cg = Cgroup::new(h, String::from("pid_resources")).unwrap();
     {
         let res = Resources {
             pid: PidResources {


### PR DESCRIPTION
Support to set threaded mode in cgroup v2. The premise of switching to threaded mode is that only the cgroup of cpuset, cpu and pids is supported.

Fixes: #90

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>