### PR TITLE
error: replace cause method with source

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -85,7 +85,7 @@ impl fmt::Display for Error {
 }
 
 impl StdError for Error {
-    fn cause(&self) -> Option<&dyn StdError> {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         #[allow(clippy::manual_map)]
         match self.cause {
             Some(ref x) => Some(&**x),


### PR DESCRIPTION
cause method for std::error::Error is depricated by rust, source method is recommended.

Fixes: #107
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>