### PR TITLE
devices: Throw an error if device resources are invalid

### DIFF
--- a/src/devices.rs
+++ b/src/devices.rs
@@ -171,9 +171,9 @@ impl ControllerInternal for DevicesController {
 
         for i in &res.devices {
             if i.allow {
-                let _ = self.allow_device(i.devtype, i.major, i.minor, &i.access);
+                self.allow_device(i.devtype, i.major, i.minor, &i.access)?;
             } else {
-                let _ = self.deny_device(i.devtype, i.major, i.minor, &i.access);
+                self.deny_device(i.devtype, i.major, i.minor, &i.access)?;
             }
         }
 


### PR DESCRIPTION
The cgroup-rs should throw errors while setting devices cgroup if the rule is invalid. For example, if a cgroup has permissions of some devices. Then we set a `a *:* rwm` to its parent's `devices.deny`. An error should be thrown to make users realize that it is a invalid rule.