### PR TITLE
add .path() method

### DIFF
--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -73,6 +73,11 @@ impl Cgroup {
         self.hier.v2()
     }
 
+    /// Return the path the cgroup is located at.
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+
     /// Create this control group.
     fn create(&self) -> Result<()> {
         if self.hier.v2() {


### PR DESCRIPTION
Adds a `.path()` method that allows the user to retrieve the path the cgroup is located at.