### PR TITLE
Minor changes for cgroup and devices subsystem

### DIFF
--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -74,7 +74,7 @@ impl Cgroup {
     }
 
     /// Create this control group.
-    fn create(&self) -> Result<()> {
+    pub fn create(&self) -> Result<()> {
         if self.hier.v2() {
             create_v2_cgroup(self.hier.root(), &self.path, &self.specified_controllers)
         } else {
@@ -491,6 +491,13 @@ impl Cgroup {
         v.sort();
         v.dedup();
         v
+    }
+
+    /// Checks if the cgroup exists.
+    ///
+    /// Returns true if at least one subsystem exists.
+    pub fn exists(&self) -> bool {
+        self.subsystems().iter().any(|e| e.to_controller().exists())
     }
 }
 

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -239,7 +239,13 @@ impl DevicesController {
         let final_str = format!("{} {}:{} {}", devtype.to_char(), major, minor, perms);
         self.open_path("devices.allow", true).and_then(|mut file| {
             file.write_all(final_str.as_ref()).map_err(|e| {
-                Error::with_cause(WriteFailed("devices.allow".to_string(), final_str), e)
+                Error::with_cause(
+                    WriteFailed(
+                        self.get_path().join("devices.allow").display().to_string(),
+                        final_str,
+                    ),
+                    e,
+                )
             })
         })
     }
@@ -272,7 +278,13 @@ impl DevicesController {
         let final_str = format!("{} {}:{} {}", devtype.to_char(), major, minor, perms);
         self.open_path("devices.deny", true).and_then(|mut file| {
             file.write_all(final_str.as_ref()).map_err(|e| {
-                Error::with_cause(WriteFailed("devices.deny".to_string(), final_str), e)
+                Error::with_cause(
+                    WriteFailed(
+                        self.get_path().join("devices.deny").display().to_string(),
+                        final_str,
+                    ),
+                    e,
+                )
             })
         })
     }


### PR DESCRIPTION
The changes include:

- Expose `create()` and add `exists()` for `Cgroup`: The changes are allowed to load cgroup and test if the cgroup exists. If not exists, performing the `create()` directly to avoid performing `Cgroup::new()`.
- Make path of devices cgroup error more details: The origin path is either `devices.allow` or `devices.deny`. It not shows which cgroup it belongs to.