### PR TITLE
memory: use `peak` in `max_usage_in_bytes`

### DIFF
--- a/src/memory.rs
+++ b/src/memory.rs
@@ -593,7 +593,10 @@ impl MemController {
                 .open_path("memory.current", false)
                 .and_then(read_u64_from)
                 .unwrap_or(0),
-            max_usage_in_bytes: 0,
+            max_usage_in_bytes: self
+                .open_path("memory.peak", false)
+                .and_then(read_u64_from)
+                .unwrap_or(0),
             move_charge_at_immigrate: 0,
             numa_stat: NumaStat::default(),
             oom_control: OomControl::default(),
@@ -736,7 +739,10 @@ impl MemController {
                 .open_path("memory.swap.current", false)
                 .and_then(read_u64_from)
                 .unwrap_or(0),
-            max_usage_in_bytes: 0,
+            max_usage_in_bytes: self
+                .open_path("memory.swap.peak", false)
+                .and_then(read_u64_from)
+                .unwrap_or(0),
         }
     }
 


### PR DESCRIPTION
Kernel 5.19 introduces `memory.peak` and kernel 6.5 introduces `memory.swap.peak` to expose the memory and swap usage watermark. This change use these values to fill `max_usage_in_bytes`.