### PR TITLE
controllers parsing is resilient to trailing newline

### DIFF
--- a/src/cgroup.rs
+++ b/src/cgroup.rs
@@ -521,7 +521,7 @@ fn supported_controllers() -> Vec<String> {
     let ret = fs::read_to_string(p.as_str());
     ret.unwrap_or_default()
         .split(' ')
-        .map(|x| x.to_string())
+        .map(|x| x.trim().to_string())
         .collect::<Vec<String>>()
 }
 


### PR DESCRIPTION
In older kernel versions (tested with 5.10.208), the cgroup.controllers files ends with a newline. This newline is not trimmed and as such the application later can incorrectly consider that the last controller is not supported