### PR TITLE
hierarchies: Remove outdated documentation

### DIFF
--- a/src/hierarchies.rs
+++ b/src/hierarchies.rs
@@ -5,9 +5,6 @@
 //
 
 //! This module represents the various control group hierarchies the Linux kernel supports.
-//!
-//! Currently, we only support the cgroupv1 hierarchy, but in the future we will add support for
-//! the Unified Hierarchy.
 
 use std::fs;
 use std::fs::File;


### PR DESCRIPTION
The documentation in the hierarchies module is outdated, this project does support cgroups2 and the unified hierarchy :)