### PR TITLE
fix(Controller): Errors are hidden by default

### DIFF
--- a/src/fs/cgroup.rs
+++ b/src/fs/cgroup.rs
@@ -84,9 +84,9 @@ impl Cgroup {
         if self.hier.v2() {
             create_v2_cgroup(self.hier.root(), &self.path, &self.specified_controllers)
         } else {
-            for subsystem in &self.subsystems {
-                subsystem.to_controller().create();
-            }
+            self.subsystems
+                .iter()
+                .try_for_each(|subsystem| subsystem.to_controller().create())?;
             Ok(())
         }
     }

--- a/src/systemd/dbus/client.rs
+++ b/src/systemd/dbus/client.rs
@@ -248,7 +248,7 @@ pub mod tests {
         String::from_utf8_lossy(&output.stdout).to_string()
     }
 
-    fn start_default_cgroup(pid: CgroupPid, unit: &str) -> SystemdClient {
+    fn start_default_cgroup(pid: CgroupPid, unit: &'_ str) -> SystemdClient<'_> {
         let mut props = PropertiesBuilder::default_cgroup(TEST_SLICE, unit).build();
         props.push((PIDS, Value::Array(vec![pid.pid as u32].into())));
         let cgroup = SystemdClient::new(unit, props).unwrap();


### PR DESCRIPTION
I don't think errors should be hidden here, it will cause the error to occur in the subsequent process, and I think this design is incorrect.
you can choose to ignore this error ,but should not hide it in inner. 
```
  let cg = Cgroup::new(hierarchies::auto(), path).unwrap();
  let mem_controller: &MemController = cg.controller_of().unwrap();
  mem_controller.set_limit(10 * 1024 * 1024).unwrap(); // 10M
```

this will case the panic occur in set_limit,this is unreasonable.