### PR TITLE
Add support for kata-agent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ log = "0.4"
 nix = { version = "0.25.0", default-features = false, features = ["event", "fs", "process"] }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
 thiserror = "1"
 oci-spec = { version = "0.8.1", optional = true }
 zbus = "5.8"
@@ -28,4 +29,4 @@ nix = "0.25"
 
 [features]
 default = []
-oci = ["oci-spec"]
+oci = ["oci-spec", "serde", "serde_json"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub enum FreezerState {
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct CgroupPid {
     /// The process identifier
-    pub pid: u64,
+    pid: u64,
 }
 
 impl From<u64> for CgroupPid {
@@ -46,6 +46,28 @@ impl From<u64> for CgroupPid {
 impl From<&std::process::Child> for CgroupPid {
     fn from(u: &std::process::Child) -> CgroupPid {
         CgroupPid { pid: u.id() as u64 }
+    }
+}
+
+impl From<u32> for CgroupPid {
+    fn from(u: u32) -> CgroupPid {
+        CgroupPid { pid: u as u64 }
+    }
+}
+
+impl From<i32> for CgroupPid {
+    fn from(u: i32) -> CgroupPid {
+        CgroupPid { pid: u as u64 }
+    }
+}
+
+impl CgroupPid {
+    pub fn set(&mut self, pid: u64) {
+        self.pid = pid;
+    }
+
+    pub fn as_raw(&self) -> u64 {
+        self.pid
     }
 }
 

--- a/src/manager/error.rs
+++ b/src/manager/error.rs
@@ -25,4 +25,7 @@ pub enum Error {
 
     #[error("systemd dbus error: {0}")]
     SystemdDbus(#[from] SystemdDbusError),
+
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
 }

--- a/src/manager/fs.rs
+++ b/src/manager/fs.rs
@@ -12,6 +12,7 @@ use oci_spec::runtime::{
     LinuxBlockIo, LinuxCpu, LinuxDeviceCgroup, LinuxHugepageLimit, LinuxMemory, LinuxNetwork,
     LinuxPids, LinuxResources,
 };
+use serde::{Deserialize, Serialize};
 
 use crate::fs::blkio::{BlkIoController, BlkIoData, IoService, IoStat};
 use crate::fs::cgroup::UNIFIED_MOUNTPOINT;
@@ -42,7 +43,7 @@ const MOUNTINFO_PATH: &str = "/proc/self/mountinfo";
 ///
 /// This manager deals with `LinuxResources` conformed to the OCI runtime
 /// specification, so that it allows users not to do type conversions.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FsManager {
     /// Cgroup subsystem paths read from `/proc/self/cgroup`
     /// - cgroup v1: <subsystem> -> <path>
@@ -55,6 +56,7 @@ pub struct FsManager {
     /// - cgroup v2: "/sys/fs/cgroup/<base>"
     base: String,
     /// Cgroup managed by this manager.
+    #[serde(skip)]
     cgroup: Cgroup,
 }
 
@@ -869,6 +871,11 @@ impl Manager for FsManager {
 
     fn mounts(&self) -> &HashMap<String, String> {
         &self.mounts
+    }
+
+    fn serialize(&self) -> Result<String> {
+        let json = serde_json::to_string(self)?;
+        Ok(json)
     }
 
     fn systemd(&self) -> bool {

--- a/src/manager/fs.rs
+++ b/src/manager/fs.rs
@@ -85,7 +85,7 @@ impl FsManager {
 
 impl FsManager {
     /// Create the cgroups if they are not created yet.
-    pub(crate) fn create_cgroups(&mut self) -> Result<()> {
+    pub fn create_cgroups(&mut self) -> Result<()> {
         if self.exists() {
             return Ok(());
         }

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -78,6 +78,9 @@ pub trait Manager: Send + Sync {
     /// mappings of relative paths see "paths()".
     fn mounts(&self) -> &HashMap<String, String>;
 
+    /// Serialize the cgroup manager to a string in the format of JSON.
+    fn serialize(&self) -> Result<String>;
+
     /// Indicate whether the cgroup manager is using systemd.
     fn systemd(&self) -> bool;
 

--- a/src/manager/mod.rs
+++ b/src/manager/mod.rs
@@ -4,14 +4,15 @@
 //
 
 mod error;
-use std::collections::HashMap;
-
 pub use error::{Error, Result};
 mod fs;
 pub use fs::FsManager;
 mod systemd;
 pub use systemd::SystemdManager;
 mod conv;
+
+use std::collections::HashMap;
+use std::fmt::Debug;
 
 use oci_spec::runtime::LinuxResources;
 
@@ -25,7 +26,7 @@ pub fn is_systemd_cgroup(cgroups_path: &str) -> bool {
 }
 
 /// Manage cgroups designed for OCI containers.
-pub trait Manager: Send + Sync {
+pub trait Manager: Send + Sync + Debug {
     /// Add a process specified by its tgid.
     fn add_proc(&mut self, tgid: CgroupPid) -> Result<()>;
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -13,6 +13,7 @@ pub struct CgroupStats {
     pub pids: PidsCgroupStats,
     pub blkio: BlkioCgroupStats,
     pub hugetlb: HugeTlbCgroupStats,
+    pub devices: DevicesCgroupStats,
 }
 
 #[derive(Debug, Default)]
@@ -153,4 +154,17 @@ pub struct HugeTlbStat {
     pub usage: u64,
     pub max_usage: u64,
     pub fail_cnt: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct DeviceCgroupStat {
+    pub dev_type: String,
+    pub major: i64,
+    pub minor: i64,
+    pub access: String,
+}
+
+#[derive(Debug, Default)]
+pub struct DevicesCgroupStats {
+    pub list: Vec<DeviceCgroupStat>,
 }

--- a/src/systemd/cpu.rs
+++ b/src/systemd/cpu.rs
@@ -4,8 +4,10 @@
 //
 
 use crate::systemd::error::{Error, Result};
+use crate::systemd::props::Value;
 use crate::systemd::{
-    CPU_QUOTA_PERIOD_US, CPU_QUOTA_PER_SEC_US, CPU_SHARES, CPU_SYSTEMD_VERSION, CPU_WEIGHT,
+    Property, CPU_QUOTA_PERIOD_US, CPU_QUOTA_PER_SEC_US, CPU_SHARES, CPU_SYSTEMD_VERSION,
+    CPU_WEIGHT,
 };
 
 /// Returns the property for CPU shares.
@@ -14,22 +16,22 @@ use crate::systemd::{
 /// MUST be converted, see [1] and `convert_shares_to_v2()`.
 ///
 /// 1: https://github.com/containers/crun/blob/main/crun.1.md#cgroup-v2
-pub fn shares(shares: u64, v2: bool) -> Result<(&'static str, u64)> {
+pub fn shares(shares: u64, v2: bool) -> Result<Property> {
     let id = if v2 { CPU_WEIGHT } else { CPU_SHARES };
 
-    Ok((id, shares))
+    Ok((id.to_string(), Value::U64(shares)))
 }
 
 /// Returns the property for CPU period.
-pub fn period(period: u64, systemd_version: usize) -> Result<(&'static str, u64)> {
+pub fn period(period: u64, systemd_version: usize) -> Result<Property> {
     if systemd_version < CPU_SYSTEMD_VERSION {
         return Err(Error::ObsoleteSystemd);
     }
 
-    Ok((CPU_QUOTA_PERIOD_US, period))
+    Ok((CPU_QUOTA_PERIOD_US.to_string(), Value::U64(period)))
 }
 
 /// Return the property for CPU quota.
-pub fn quota(quota: u64) -> Result<(&'static str, u64)> {
-    Ok((CPU_QUOTA_PER_SEC_US, quota))
+pub fn quota(quota: u64) -> Result<Property> {
+    Ok((CPU_QUOTA_PER_SEC_US.to_string(), Value::U64(quota)))
 }

--- a/src/systemd/cpuset.rs
+++ b/src/systemd/cpuset.rs
@@ -6,30 +6,31 @@
 use bit_vec::BitVec;
 
 use crate::systemd::error::{Error, Result};
-use crate::systemd::{ALLOWED_CPUS, ALLOWED_MEMORY_NODES, CPUSET_SYSTEMD_VERSION};
+use crate::systemd::props::Value;
+use crate::systemd::{Property, ALLOWED_CPUS, ALLOWED_MEMORY_NODES, CPUSET_SYSTEMD_VERSION};
 
 const BYTE_IN_BITS: usize = 8;
 
 /// Returns the property for cpuset CPUs.
-pub fn cpus(cpus: &str, systemd_version: usize) -> Result<(&'static str, Vec<u8>)> {
+pub fn cpus(cpus: &str, systemd_version: usize) -> Result<Property> {
     if systemd_version < CPUSET_SYSTEMD_VERSION {
         return Err(Error::ObsoleteSystemd);
     }
 
     let mask = convert_list_to_mask(cpus)?;
 
-    Ok((ALLOWED_CPUS, mask))
+    Ok((ALLOWED_CPUS.to_string(), Value::ArrayU8(mask)))
 }
 
 /// Returns the property for cpuset memory nodes.
-pub fn mems(mems: &str, systemd_version: usize) -> Result<(&'static str, Vec<u8>)> {
+pub fn mems(mems: &str, systemd_version: usize) -> Result<Property> {
     if systemd_version < CPUSET_SYSTEMD_VERSION {
         return Err(Error::ObsoleteSystemd);
     }
 
     let mask = convert_list_to_mask(mems)?;
 
-    Ok((ALLOWED_MEMORY_NODES, mask))
+    Ok((ALLOWED_MEMORY_NODES.to_string(), Value::ArrayU8(mask)))
 }
 
 /// Convert cpuset cpus/mems from the string in comma-separated list format

--- a/src/systemd/memory.rs
+++ b/src/systemd/memory.rs
@@ -4,29 +4,30 @@
 //
 
 use crate::systemd::error::{Error, Result};
-use crate::systemd::{MEMORY_LIMIT, MEMORY_LOW, MEMORY_MAX, MEMORY_SWAP_MAX};
+use crate::systemd::props::Value;
+use crate::systemd::{Property, MEMORY_LIMIT, MEMORY_LOW, MEMORY_MAX, MEMORY_SWAP_MAX};
 
 /// Returns the property for memory limit.
-pub fn limit(limit: i64, v2: bool) -> Result<(&'static str, u64)> {
+pub fn limit(limit: i64, v2: bool) -> Result<Property> {
     let id = if v2 { MEMORY_MAX } else { MEMORY_LIMIT };
 
-    Ok((id, limit as u64))
+    Ok((id.to_string(), Value::U64(limit as u64)))
 }
 
 /// Returns the property for memory limit.
-pub fn low(low: i64, v2: bool) -> Result<(&'static str, u64)> {
+pub fn low(low: i64, v2: bool) -> Result<Property> {
     if !v2 {
         return Err(Error::CgroupsV1NotSupported);
     }
 
-    Ok((MEMORY_LOW, low as u64))
+    Ok((MEMORY_LOW.to_string(), Value::U64(low as u64)))
 }
 
 /// Returns the property for memory swap.
-pub fn swap(swap: i64, v2: bool) -> Result<(&'static str, u64)> {
+pub fn swap(swap: i64, v2: bool) -> Result<Property> {
     if !v2 {
         return Err(Error::CgroupsV1NotSupported);
     }
 
-    Ok((MEMORY_SWAP_MAX, swap as u64))
+    Ok((MEMORY_SWAP_MAX.to_string(), Value::U64(swap as u64)))
 }

--- a/src/systemd/pids.rs
+++ b/src/systemd/pids.rs
@@ -4,8 +4,9 @@
 //
 
 use crate::systemd::error::Result;
-use crate::systemd::TASKS_MAX;
+use crate::systemd::props::Value;
+use crate::systemd::{Property, TASKS_MAX};
 
-pub fn max(max: i64) -> Result<(&'static str, u64)> {
-    Ok((TASKS_MAX, max as u64))
+pub fn max(max: i64) -> Result<Property> {
+    Ok((TASKS_MAX.to_string(), Value::U64(max as u64)))
 }


### PR DESCRIPTION
**manager: Make FsManager and SystemdManager serializable**

The kata-agent (de)serializes managers in child initialization. The `oci`
feature relies on `serde` crate to provide the ability to serialize.

Zbus's value uses variable reference, which is hard to serialize. `Value`
is introduced to take the ownership of the value, so that we can remove
lifetime annotations from `SystemdClient`, also from `SystemdManager`.

The types supported by the `Value` only include the types that are in use.
Later on, more types can be added to `Value` if needed.

**manager: Add Debug trait for Manager**

Both `FsManager` and `SystemdManger` support `Debug` trait, so we can add
it to `Manager` as well.

**cgroups-rs: Enhance CgroupPid**

Implement `From<u32>` and `From<i32>` for `CgroupPid` to allow conversion
from these types directly. Add `as_raw()` method to retrieve the raw PID
value, and add `set()` method to modify the PID value.

**manager: Make create_cgroups() public**

The kata-agent expects to create sandbox cgroup without need to wait for
the first process/thread to be added to the cgroup.

**manager: Add devices cgroup stats**

The stats allow users to retrieve device whitelist from the cgroupfs.

**manager: Skip resources whose controller doesn't exist**

Not all cgroup controllers are available, so we should skip setting cgroups
for those controllers.
