### PR TITLE
systemd: Do not check systemd version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,22 +72,11 @@ pub mod tests {
         child
     }
 
-    pub fn systemd_version() -> Option<usize> {
+    pub fn systemd_version() -> Option<String> {
         let output = Command::new("systemd").arg("--version").output().ok()?; // Return None if command execution fails
-
         if !output.status.success() {
             return None;
         }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        // The first line is typically like "systemd 254 (254.5-1-arch)"
-        let first_line = stdout.lines().next()?;
-        let mut words = first_line.split_whitespace();
-
-        words.next()?; // Skip the "systemd" word
-        let version_str = words.next()?; // The version number as string
-
-        version_str.parse::<usize>().ok()
+        Some(String::from_utf8_lossy(&output.stdout).to_string())
     }
 }

--- a/src/systemd/cpu.rs
+++ b/src/systemd/cpu.rs
@@ -3,10 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //
 
-use crate::systemd::error::{Error, Result};
-use crate::systemd::{
-    CPU_QUOTA_PERIOD_US, CPU_QUOTA_PER_SEC_US, CPU_SHARES, CPU_SYSTEMD_VERSION, CPU_WEIGHT,
-};
+use crate::systemd::error::Result;
+use crate::systemd::{CPU_QUOTA_PERIOD_US, CPU_QUOTA_PER_SEC_US, CPU_SHARES, CPU_WEIGHT};
 
 /// Returns the property for CPU shares.
 ///
@@ -21,11 +19,7 @@ pub fn shares(shares: u64, v2: bool) -> Result<(&'static str, u64)> {
 }
 
 /// Returns the property for CPU period.
-pub fn period(period: u64, systemd_version: usize) -> Result<(&'static str, u64)> {
-    if systemd_version < CPU_SYSTEMD_VERSION {
-        return Err(Error::ObsoleteSystemd);
-    }
-
+pub fn period(period: u64) -> Result<(&'static str, u64)> {
     Ok((CPU_QUOTA_PERIOD_US, period))
 }
 

--- a/src/systemd/cpuset.rs
+++ b/src/systemd/cpuset.rs
@@ -6,29 +6,19 @@
 use bit_vec::BitVec;
 
 use crate::systemd::error::{Error, Result};
-use crate::systemd::{ALLOWED_CPUS, ALLOWED_MEMORY_NODES, CPUSET_SYSTEMD_VERSION};
+use crate::systemd::{ALLOWED_CPUS, ALLOWED_MEMORY_NODES};
 
 const BYTE_IN_BITS: usize = 8;
 
 /// Returns the property for cpuset CPUs.
-pub fn cpus(cpus: &str, systemd_version: usize) -> Result<(&'static str, Vec<u8>)> {
-    if systemd_version < CPUSET_SYSTEMD_VERSION {
-        return Err(Error::ObsoleteSystemd);
-    }
-
+pub fn cpus(cpus: &str) -> Result<(&'static str, Vec<u8>)> {
     let mask = convert_list_to_mask(cpus)?;
-
     Ok((ALLOWED_CPUS, mask))
 }
 
 /// Returns the property for cpuset memory nodes.
-pub fn mems(mems: &str, systemd_version: usize) -> Result<(&'static str, Vec<u8>)> {
-    if systemd_version < CPUSET_SYSTEMD_VERSION {
-        return Err(Error::ObsoleteSystemd);
-    }
-
+pub fn mems(mems: &str) -> Result<(&'static str, Vec<u8>)> {
     let mask = convert_list_to_mask(mems)?;
-
     Ok((ALLOWED_MEMORY_NODES, mask))
 }
 

--- a/src/systemd/dbus/error.rs
+++ b/src/systemd/dbus/error.rs
@@ -12,7 +12,4 @@ pub enum Error {
 
     #[error("dbus error: {0}")]
     Dbus(#[from] zbus::Error),
-
-    #[error("corrupted systemd version: {0}")]
-    CorruptedSystemdVersion(String),
 }

--- a/src/systemd/error.rs
+++ b/src/systemd/error.rs
@@ -10,9 +10,6 @@ pub enum Error {
     #[error("invalid argument")]
     InvalidArgument,
 
-    #[error("obsolete systemd, please upgrade your systemd")]
-    ObsoleteSystemd,
-
     #[error("resource not supported by cgroups v1")]
     CgroupsV1NotSupported,
 }

--- a/src/systemd/mod.rs
+++ b/src/systemd/mod.rs
@@ -20,6 +20,3 @@ pub const DEFAULT_SLICE: &str = "system.slice";
 
 pub const SLICE_SUFFIX: &str = ".slice";
 pub const SCOPE_SUFFIX: &str = ".scope";
-
-pub const CPU_SYSTEMD_VERSION: usize = 242;
-pub const CPUSET_SYSTEMD_VERSION: usize = 244;


### PR DESCRIPTION
The systemd version is purely informational and should not be parsed, as
documented in the [1]. In practice, systemd version has different formats
on OpenShift and Ubuntu.

This commit skips the version check and allows all operations. The errors
will be thrown from dbus when performing unsupported operations on obsolete
versions of systemd.

1: https://www.freedesktop.org/software/systemd/man/latest/org.freedesktop.systemd1.html