### PR TITLE
Fix code sample in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,38 +9,43 @@ Native Rust library for managing Linux control groups. Supports both cgroups v1 
 ### Create a control group using the builder pattern
 
 ```rust
-use cgroups_rs::*;
-use cgroups_rs::cgroup_builder::*;
+use cgroups_rs::{
+    CgroupPid,
+    fs::{Cgroup, Controller, cgroup_builder::*, cpu::CpuController, hierarchies},
+};
 
-// Acquire a handle for the cgroup hierarchy.
-let hier = cgroups_rs::hierarchies::auto();
+fn main() {
+    // Acquire a handle for the cgroup hierarchy.
+    let hier = hierarchies::auto();
 
-// Use the builder pattern (see the documentation to create the control group)
-//
-// This creates a control group named "example" in the V1 hierarchy.
+    // Use the builder pattern (see the documentation to create the control group)
+    //
+    // This creates a control group named "example" in the V1 hierarchy.
     let cg: Cgroup = CgroupBuilder::new("example")
         .cpu()
         .shares(85)
         .done()
-        .build(hier);
+        .build(hier)
+        .unwrap();
 
-// Now `cg` is a control group that gets 85% of the CPU time in relative to
-// other control groups.
+    // Now `cg` is a control group that gets 85% of the CPU time in relative to
+    // other control groups.
 
-// Get a handle to the CPU controller.
-let cpus: &cgroups_rs::cpu::CpuController = cg.controller_of().unwrap();
-cpus.add_task(&CgroupPid::from(1234u64));
+    // Get a handle to the CPU controller.
+    let cpus: &CpuController = cg.controller_of().unwrap();
+    cpus.add_task(&CgroupPid::from(1234u64)).unwrap();
 
-// [...]
+    // [...]
 
-// Finally, clean up and delete the control group.
-cg.delete();
+    // Finally, clean up and delete the control group.
+    cg.delete().unwrap();
 
-// Note that `Cgroup` does not implement `Drop` and therefore when the
-// structure is dropped, the Cgroup will stay around. This is because, later
-// you can then re-create the `Cgroup` using `load()`. We aren't too set on
-// this behavior, so it might change in the feature. Rest assured, it will be a
-// major version change.
+    // Note that `Cgroup` does not implement `Drop` and therefore when the
+    // structure is dropped, the Cgroup will stay around. This is because, later
+    // you can then re-create the `Cgroup` using `load()`. We aren't too set on
+    // this behavior, so it might change in the feature. Rest assured, it will be a
+    // major version change.
+}
 ```
 
 ## Disclaimer


### PR DESCRIPTION
The README code example no longer matches the current public API. Update the example and mainly fix the imports. Also put the code into a main function so it has proper structure and could be run immediately by someone.