### PR TITLE
build: Bump oci-spec to 0.10.0

### DIFF
--- a/.github/workflows/bvt.yaml
+++ b/.github/workflows/bvt.yaml
@@ -1,7 +1,7 @@
 name: BVT
 on: [pull_request]
 env:
-  RUST_VERSION: 1.85.1
+  RUST_VERSION: 1.90.0
 jobs:
   build:
     name: Build
@@ -34,5 +34,4 @@ jobs:
       - uses: actions/checkout@v2
       - run: rustup install ${{ env.RUST_VERSION }} && rustup default ${{ env.RUST_VERSION }}
       - run: make test
-
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ nix = { version = "0.25.0", default-features = false, features = ["event", "fs",
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1"
-oci-spec = { version = "0.8.1", optional = true }
+oci-spec = { version = "0.10.0", optional = true }
 zbus = "5.8"
 bit-vec = "0.6"
 


### PR DESCRIPTION
cgroups-rs exposes oci-spec types in its public API (e.g. Manager::set() takes &LinuxResources), so the version pinned here dictates which oci-spec version every consumer must use: 0.x lines are semver-incompatible, and a consumer on a newer oci-spec gets "expected LinuxResources, found LinuxResources" type mismatches.

Kata Containers is moving its workspace to oci-spec 0.10.0 and cannot call into cgroups-rs until this crate follows. The 0.8 to 0.10 changes are additive for everything cgroups-rs touches (no code changes needed): the crate builds warning-free with the oci feature and the unit tests pass (the only failures are the pre-existing fs manager tests that need root to write cgroupfs).