### PR TITLE
fs: Rewrite v2 OOM notification using inotify on memory.events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 log = "0.4"
-nix = { version = "0.25.0", default-features = false, features = ["event", "fs", "process"] }
+nix = { version = "0.25.0", default-features = false, features = ["event", "fs", "process", "inotify"] }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 async-io = "2"
 futures-lite = "2"
 log = "0.4"
-nix = { version = "0.31", default-features = false, features = ["event", "fs", "process", "signal"] }
+nix = { version = "0.31", default-features = false, features = ["event", "fs", "process", "signal", "inotify"] }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1"

--- a/src/fs/events.rs
+++ b/src/fs/events.rs
@@ -4,9 +4,11 @@
 //
 
 use eventfd::{eventfd, EfdFlags};
+use nix::errno::Errno;
 use nix::sys::eventfd;
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use std::fs::{self, File};
-use std::io::Read;
+use std::io::{BufRead, BufReader, Read};
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver};
@@ -15,14 +17,81 @@ use std::thread;
 use crate::fs::error::ErrorKind::*;
 use crate::fs::error::*;
 
-// notify_on_oom returns channel on which you can expect event about OOM,
-// if process died without OOM this channel will be closed.
-pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
-    register_memory_event(key, dir, "memory.oom_control", "")
+fn read_oom_count(path: &Path) -> Result<u64> {
+    let file = File::open(path)
+        .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line =
+            line.map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+
+        let mut parts = line.split_whitespace();
+        if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
+            if key == "oom" {
+                let count: u64 = value
+                    .parse::<u64>()
+                    .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+                return Ok(count);
+            }
+        }
+    }
+    Err(Error::from_string("oom not found".to_string()))
 }
 
 // notify_on_oom returns channel on which you can expect event about OOM,
-// if process died without OOM this channel will be closed.
+// if cgroup was destroyed without OOM this channel will be closed.
+pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
+    let path = dir.join("memory.events");
+    let inotify = Inotify::init(InitFlags::IN_CLOEXEC)
+        .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+    inotify
+        .add_watch(&path, AddWatchFlags::IN_MODIFY)
+        .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+
+    // Establish the watch before taking the baseline so changes after the
+    // baseline read are guaranteed to have a queued inotify event.
+    let mut base = read_oom_count(&path)?;
+    let (sender, receiver) = mpsc::channel();
+    let key = key.to_string();
+
+    thread::spawn(move || loop {
+        let events = match inotify.read_events() {
+            Ok(events) => events,
+            Err(Errno::EINTR) => continue,
+            Err(_) => return,
+        };
+
+        for event in events {
+            if event
+                .mask
+                .intersects(AddWatchFlags::IN_IGNORED | AddWatchFlags::IN_UNMOUNT)
+            {
+                return;
+            }
+
+            if event
+                .mask
+                .intersects(AddWatchFlags::IN_MODIFY | AddWatchFlags::IN_Q_OVERFLOW)
+            {
+                let count = match read_oom_count(&path) {
+                    Ok(count) => count,
+                    Err(_) => return,
+                };
+
+                if count > base {
+                    if sender.send(key.clone()).is_err() {
+                        return;
+                    }
+                    base = count;
+                }
+            }
+        }
+    });
+    Ok(receiver)
+}
+
+// notify_on_oom returns channel on which you can expect event about OOM,
+// if cgroup was destroyed without OOM this channel will be closed.
 pub fn notify_on_oom_v1(key: &str, dir: &Path) -> Result<Receiver<String>> {
     register_memory_event(key, dir, "memory.oom_control", "")
 }
@@ -89,4 +158,98 @@ fn register_memory_event(
     });
 
     Ok(receiver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn test_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cgroups-rs-events-test-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_read_oom_count() {
+        let dir = test_dir();
+        let path = dir.join("memory.events");
+
+        // full format, including the newer sock_throttled line
+        fs::write(
+            &path,
+            "low 0\nhigh 0\nmax 0\noom 3\noom_kill 0\noom_group_kill 0\nsock_throttled 0\n",
+        )
+        .unwrap();
+        assert_eq!(read_oom_count(&path).unwrap(), 3);
+
+        // line order must not matter, and missing lines are fine (older kernels)
+        fs::write(&path, "oom 7\nlow 0\n").unwrap();
+        assert_eq!(read_oom_count(&path).unwrap(), 7);
+
+        // key absent -> error
+        fs::write(&path, "low 0\nhigh 0\n").unwrap();
+        assert!(read_oom_count(&path).is_err());
+
+        // file absent -> error
+        assert!(read_oom_count(&dir.join("nope")).is_err());
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn test_notify_on_oom_v2() {
+        let dir = test_dir();
+        let events = dir.join("memory.events");
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 5\noom_kill 0\n").unwrap();
+
+        let rx = notify_on_oom_v2("test-key", &dir).unwrap();
+
+        // Pre-existing OOMs are the baseline, not notified.
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        // A kill-count change without a new OOM must not notify.
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 5\noom_kill 1\n").unwrap();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        // One new OOM produces exactly one notification.
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 6\noom_kill 1\n").unwrap();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), "test-key");
+
+        // no duplicate flood while the count stays the same
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        // A second OOM is notified again.
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 7\noom_kill 1\n").unwrap();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), "test-key");
+
+        // Destroying the cgroup closes the channel.
+        fs::remove_dir_all(&dir).unwrap();
+        let closed = (0..20).any(|_| {
+            matches!(
+                rx.recv_timeout(Duration::from_millis(200)),
+                Err(mpsc::RecvTimeoutError::Disconnected)
+            )
+        });
+        assert!(closed);
+    }
 }

--- a/src/fs/events.rs
+++ b/src/fs/events.rs
@@ -66,6 +66,9 @@ pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
     let (sender, receiver) = mpsc::channel();
     let key = key.to_string();
     let cgroup_name = cgroup_name.to_os_string();
+    // Own the path so the watcher thread can re-check liveness after a queue
+    // overflow without borrowing from the caller ('static required by spawn).
+    let dir = dir.to_path_buf();
 
     thread::spawn(move || loop {
         let events = match inotify.read_events() {
@@ -75,6 +78,28 @@ pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
         };
 
         for event in events {
+            if event.mask.intersects(AddWatchFlags::IN_Q_OVERFLOW) {
+                // The queue overflowed and events (an OOM modification or a
+                // cgroup-removal event) may have been lost. Overflow events
+                // are reported with wd == -1, so resynchronize from the
+                // current state instead of filtering by watch descriptor.
+                if !dir.exists() {
+                    return;
+                }
+                let count = match read_oom_count(&path) {
+                    Ok(count) => count,
+                    Err(_) => return,
+                };
+
+                if count > base {
+                    if sender.send(key.clone()).is_err() {
+                        return;
+                    }
+                    base = count;
+                }
+                continue;
+            }
+
             if event.wd == parent_watch
                 && event.name.as_deref() == Some(cgroup_name.as_os_str())
                 && event
@@ -91,11 +116,7 @@ pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
                 return;
             }
 
-            if event.wd == events_watch
-                && event
-                    .mask
-                    .intersects(AddWatchFlags::IN_MODIFY | AddWatchFlags::IN_Q_OVERFLOW)
-            {
+            if event.wd == events_watch && event.mask.intersects(AddWatchFlags::IN_MODIFY) {
                 let count = match read_oom_count(&path) {
                     Ok(count) => count,
                     Err(_) => return,
@@ -183,7 +204,8 @@ fn register_memory_event(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
+    use std::fs::{self, OpenOptions};
+    use std::io::Write;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::Duration;
@@ -198,6 +220,20 @@ mod tests {
         ));
         fs::create_dir_all(&dir).unwrap();
         dir
+    }
+
+    // Overwrite a watched fixture in place. Truncating (fs::write) would
+    // itself emit an IN_MODIFY that the watcher may observe while the file
+    // is empty, failing read_oom_count and disconnecting the channel.
+    // The replacement must have the same length as the current contents.
+    fn write_no_trunc(path: &Path, contents: &str) {
+        let mut file = OpenOptions::new()
+            .write(true)
+            .truncate(false)
+            .open(path)
+            .unwrap();
+        assert_eq!(file.metadata().unwrap().len(), contents.len() as u64);
+        file.write_all(contents.as_bytes()).unwrap();
     }
 
     #[test]
@@ -242,14 +278,14 @@ mod tests {
         );
 
         // A kill-count change without a new OOM must not notify.
-        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 5\noom_kill 1\n").unwrap();
+        write_no_trunc(&events, "low 0\nhigh 0\nmax 0\noom 5\noom_kill 1\n");
         assert_eq!(
             rx.recv_timeout(Duration::from_millis(200)),
             Err(mpsc::RecvTimeoutError::Timeout)
         );
 
         // One new OOM produces exactly one notification.
-        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 6\noom_kill 1\n").unwrap();
+        write_no_trunc(&events, "low 0\nhigh 0\nmax 0\noom 6\noom_kill 1\n");
         assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), "test-key");
 
         // no duplicate flood while the count stays the same
@@ -259,7 +295,7 @@ mod tests {
         );
 
         // A second OOM is notified again.
-        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 7\noom_kill 1\n").unwrap();
+        write_no_trunc(&events, "low 0\nhigh 0\nmax 0\noom 7\noom_kill 1\n");
         assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), "test-key");
 
         // Destroying the cgroup closes the channel.

--- a/src/fs/events.rs
+++ b/src/fs/events.rs
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //
 
+use nix::errno::Errno;
 use nix::sys::eventfd::{EfdFlags, EventFd};
+use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use std::fs::{self, File};
+use std::io::{BufRead, BufReader};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver};
@@ -13,14 +16,81 @@ use std::thread;
 use crate::fs::error::ErrorKind::*;
 use crate::fs::error::*;
 
-// notify_on_oom returns channel on which you can expect event about OOM,
-// if process died without OOM this channel will be closed.
-pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
-    register_memory_event(key, dir, "memory.oom_control", "")
+fn read_oom_count(path: &Path) -> Result<u64> {
+    let file = File::open(path)
+        .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+    let reader = BufReader::new(file);
+    for line in reader.lines() {
+        let line =
+            line.map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+
+        let mut parts = line.split_whitespace();
+        if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
+            if key == "oom" {
+                let count: u64 = value
+                    .parse::<u64>()
+                    .map_err(|e| Error::with_cause(ParseError, e))?;
+                return Ok(count);
+            }
+        }
+    }
+    Err(Error::from_string("oom not found".to_string()))
 }
 
 // notify_on_oom returns channel on which you can expect event about OOM,
-// if process died without OOM this channel will be closed.
+// if cgroup was destroyed without OOM this channel will be closed.
+pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
+    let path = dir.join("memory.events");
+    let inotify = Inotify::init(InitFlags::IN_CLOEXEC)
+        .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+    inotify
+        .add_watch(&path, AddWatchFlags::IN_MODIFY)
+        .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
+
+    // Establish the watch before taking the baseline so changes after the
+    // baseline read are guaranteed to have a queued inotify event.
+    let mut base = read_oom_count(&path)?;
+    let (sender, receiver) = mpsc::channel();
+    let key = key.to_string();
+
+    thread::spawn(move || loop {
+        let events = match inotify.read_events() {
+            Ok(events) => events,
+            Err(Errno::EINTR) => continue,
+            Err(_) => return,
+        };
+
+        for event in events {
+            if event
+                .mask
+                .intersects(AddWatchFlags::IN_IGNORED | AddWatchFlags::IN_UNMOUNT)
+            {
+                return;
+            }
+
+            if event
+                .mask
+                .intersects(AddWatchFlags::IN_MODIFY | AddWatchFlags::IN_Q_OVERFLOW)
+            {
+                let count = match read_oom_count(&path) {
+                    Ok(count) => count,
+                    Err(_) => return,
+                };
+
+                if count > base {
+                    if sender.send(key.clone()).is_err() {
+                        return;
+                    }
+                    base = count;
+                }
+            }
+        }
+    });
+    Ok(receiver)
+}
+
+// notify_on_oom returns channel on which you can expect event about OOM,
+// if cgroup was destroyed without OOM this channel will be closed.
 pub fn notify_on_oom_v1(key: &str, dir: &Path) -> Result<Receiver<String>> {
     register_memory_event(key, dir, "memory.oom_control", "")
 }
@@ -84,4 +154,98 @@ fn register_memory_event(
     });
 
     Ok(receiver)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn test_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cgroups-rs-events-test-{}-{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::SeqCst)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_read_oom_count() {
+        let dir = test_dir();
+        let path = dir.join("memory.events");
+
+        // full format, including the newer sock_throttled line
+        fs::write(
+            &path,
+            "low 0\nhigh 0\nmax 0\noom 3\noom_kill 0\noom_group_kill 0\nsock_throttled 0\n",
+        )
+        .unwrap();
+        assert_eq!(read_oom_count(&path).unwrap(), 3);
+
+        // line order must not matter, and missing lines are fine (older kernels)
+        fs::write(&path, "oom 7\nlow 0\n").unwrap();
+        assert_eq!(read_oom_count(&path).unwrap(), 7);
+
+        // key absent -> error
+        fs::write(&path, "low 0\nhigh 0\n").unwrap();
+        assert!(read_oom_count(&path).is_err());
+
+        // file absent -> error
+        assert!(read_oom_count(&dir.join("nope")).is_err());
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn test_notify_on_oom_v2() {
+        let dir = test_dir();
+        let events = dir.join("memory.events");
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 5\noom_kill 0\n").unwrap();
+
+        let rx = notify_on_oom_v2("test-key", &dir).unwrap();
+
+        // Pre-existing OOMs are the baseline, not notified.
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        // A kill-count change without a new OOM must not notify.
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 5\noom_kill 1\n").unwrap();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        // One new OOM produces exactly one notification.
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 6\noom_kill 1\n").unwrap();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), "test-key");
+
+        // no duplicate flood while the count stays the same
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        // A second OOM is notified again.
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 7\noom_kill 1\n").unwrap();
+        assert_eq!(rx.recv_timeout(Duration::from_secs(5)).unwrap(), "test-key");
+
+        // Destroying the cgroup closes the channel.
+        fs::remove_dir_all(&dir).unwrap();
+        let closed = (0..20).any(|_| {
+            matches!(
+                rx.recv_timeout(Duration::from_millis(200)),
+                Err(mpsc::RecvTimeoutError::Disconnected)
+            )
+        });
+        assert!(closed);
+    }
 }

--- a/src/fs/events.rs
+++ b/src/fs/events.rs
@@ -41,17 +41,31 @@ fn read_oom_count(path: &Path) -> Result<u64> {
 // if cgroup was destroyed without OOM this channel will be closed.
 pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
     let path = dir.join("memory.events");
+    let parent = dir
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    let cgroup_name = dir.file_name().ok_or_else(|| {
+        Error::from_string(format!("cannot watch cgroup removal for {}", dir.display()))
+    })?;
     let inotify = Inotify::init(InitFlags::IN_CLOEXEC)
         .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
-    inotify
+    let parent_watch = inotify
+        .add_watch(
+            parent,
+            AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM,
+        )
+        .map_err(|e| Error::with_cause(ReadFailed(parent.display().to_string()), e))?;
+    let events_watch = inotify
         .add_watch(&path, AddWatchFlags::IN_MODIFY)
         .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
 
-    // Establish the watch before taking the baseline so changes after the
-    // baseline read are guaranteed to have a queued inotify event.
+    // Establish both watches before taking the baseline so changes after the
+    // baseline read and removal during registration have queued events.
     let mut base = read_oom_count(&path)?;
     let (sender, receiver) = mpsc::channel();
     let key = key.to_string();
+    let cgroup_name = cgroup_name.to_os_string();
 
     thread::spawn(move || loop {
         let events = match inotify.read_events() {
@@ -61,6 +75,15 @@ pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
         };
 
         for event in events {
+            if event.wd == parent_watch
+                && event.name.as_deref() == Some(cgroup_name.as_os_str())
+                && event
+                    .mask
+                    .intersects(AddWatchFlags::IN_DELETE | AddWatchFlags::IN_MOVED_FROM)
+            {
+                return;
+            }
+
             if event
                 .mask
                 .intersects(AddWatchFlags::IN_IGNORED | AddWatchFlags::IN_UNMOUNT)
@@ -68,9 +91,10 @@ pub fn notify_on_oom_v2(key: &str, dir: &Path) -> Result<Receiver<String>> {
                 return;
             }
 
-            if event
-                .mask
-                .intersects(AddWatchFlags::IN_MODIFY | AddWatchFlags::IN_Q_OVERFLOW)
+            if event.wd == events_watch
+                && event
+                    .mask
+                    .intersects(AddWatchFlags::IN_MODIFY | AddWatchFlags::IN_Q_OVERFLOW)
             {
                 let count = match read_oom_count(&path) {
                     Ok(count) => count,
@@ -247,5 +271,32 @@ mod tests {
             )
         });
         assert!(closed);
+    }
+
+    #[test]
+    fn test_notify_on_oom_v2_closes_when_cgroup_moves() {
+        let dir = test_dir();
+        let sibling_dir = dir.with_extension("sibling");
+        let moved_dir = dir.with_extension("moved");
+        let events = dir.join("memory.events");
+        fs::write(&events, "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n").unwrap();
+
+        let rx = notify_on_oom_v2("test-key", &dir).unwrap();
+
+        fs::create_dir(&sibling_dir).unwrap();
+        fs::remove_dir(&sibling_dir).unwrap();
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(200)),
+            Err(mpsc::RecvTimeoutError::Timeout)
+        );
+
+        fs::rename(&dir, &moved_dir).unwrap();
+
+        assert_eq!(
+            rx.recv_timeout(Duration::from_secs(5)),
+            Err(mpsc::RecvTimeoutError::Disconnected)
+        );
+
+        fs::remove_dir_all(&moved_dir).unwrap();
     }
 }

--- a/src/fs/memory.rs
+++ b/src/fs/memory.rs
@@ -957,15 +957,19 @@ impl MemController {
     }
 
     pub fn disable_oom_killer(&self) -> Result<()> {
-        self.open_path("memory.oom_control", true)
-            .and_then(|mut file| {
-                file.write_all("1".to_string().as_ref()).map_err(|e| {
-                    Error::with_cause(
-                        WriteFailed("memory.oom_control".to_string(), "1".to_string()),
-                        e,
-                    )
+        if self.v2 {
+            Err(Error::new(CgroupVersion))
+        } else {
+            self.open_path("memory.oom_control", true)
+                .and_then(|mut file| {
+                    file.write_all("1".to_string().as_ref()).map_err(|e| {
+                        Error::with_cause(
+                            WriteFailed("memory.oom_control".to_string(), "1".to_string()),
+                            e,
+                        )
+                    })
                 })
-            })
+        }
     }
 
     pub fn register_oom_event(&self, key: &str) -> Result<Receiver<String>> {
@@ -1002,9 +1006,12 @@ impl<'a> From<&'a Subsystem> for &'a MemController {
 
 #[cfg(test)]
 mod tests {
+    use crate::fs::error::ErrorKind;
     use crate::fs::memory::{
-        parse_memory_stat, parse_numa_stat, parse_oom_control, MemoryStat, NumaStat, OomControl,
+        parse_memory_stat, parse_numa_stat, parse_oom_control, MemController, MemoryStat, NumaStat,
+        OomControl,
     };
+    use std::path::PathBuf;
 
     static GOOD_VALUE: &str = "\
 total=51189 N0=51189 N1=123
@@ -1214,6 +1221,21 @@ total_unevictable 81920
                 total_unevictable: 81920,
                 raw,
             }
+        );
+    }
+
+    #[test]
+    fn test_disable_oom_killer_v2() {
+        // memory.oom_control does not exist in cgroup v2, so this must fail
+        // cleanly instead of trying to write a non-existent file.
+        let c = MemController::new(
+            PathBuf::from("/sys/fs/cgroup/does-not-exist"),
+            PathBuf::from("/sys/fs/cgroup"),
+            true,
+        );
+        assert_eq!(
+            c.disable_oom_killer().unwrap_err().kind(),
+            &ErrorKind::CgroupVersion
         );
     }
 }


### PR DESCRIPTION
notify_on_oom_v2 now watches memory.events with inotify and only notifies on new OOM counts, instead of the v1-only memory.oom_control eventfd. The channel is closed when the cgroup is destroyed.

Also make disable_oom_killer fail with a CgroupVersion error on cgroup v2, and add unit tests for both changes.

Fixes #136.