### PR TITLE
fs: Support freezer in cgroup v2 and add tests

### DIFF
--- a/src/fs/cgroup.rs
+++ b/src/fs/cgroup.rs
@@ -509,21 +509,40 @@ impl Cgroup {
 
 pub const UNIFIED_MOUNTPOINT: &str = "/sys/fs/cgroup";
 
+/// The freezer is not a v2 controller but a core cgroup feature exposed
+/// through the `cgroup.freeze` file. It is reported as a controller so
+/// that the v1-style API can address it uniformly.
+const FREEZER_CONTROLLER: &str = "freezer";
+
 fn enable_controllers(controllers: &[String], path: &Path) {
     let f = path.join("cgroup.subtree_control");
     for c in controllers {
+        // The freezer cannot be enabled through cgroup.subtree_control:
+        // it is a core v2 feature and not a controller.
+        if c == FREEZER_CONTROLLER {
+            continue;
+        }
         let body = format!("+{}", c);
         let _rest = fs::write(f.as_path(), body.as_bytes());
     }
 }
 
+/// The controllers supported by the unified hierarchy, including the
+/// always-available freezer core functionality.
 fn supported_controllers() -> Vec<String> {
     let p = format!("{}/{}", UNIFIED_MOUNTPOINT, "cgroup.controllers");
     let ret = fs::read_to_string(p.as_str());
-    ret.unwrap_or_default()
+    let mut controllers: Vec<String> = ret
+        .unwrap_or_default()
         .split(' ')
         .map(|x| x.trim().to_string())
-        .collect::<Vec<String>>()
+        .filter(|x| !x.is_empty())
+        .collect();
+
+    if !controllers.iter().any(|x| x == FREEZER_CONTROLLER) {
+        controllers.push(FREEZER_CONTROLLER.to_string());
+    }
+    controllers
 }
 
 fn create_v2_cgroup(

--- a/src/fs/cgroup.rs
+++ b/src/fs/cgroup.rs
@@ -7,7 +7,7 @@
 //! This module handles cgroup operations. Start here!
 
 use crate::fs::error::ErrorKind::*;
-use crate::fs::error::*;
+use crate::fs::{error::*, Controllers};
 
 use crate::fs::hierarchies::V1;
 use crate::fs::{CgroupPid, ControllIdentifier, Controller, Hierarchy, Resources, Subsystem};
@@ -509,40 +509,85 @@ impl Cgroup {
 
 pub const UNIFIED_MOUNTPOINT: &str = "/sys/fs/cgroup";
 
-/// The freezer is not a v2 controller but a core cgroup feature exposed
-/// through the `cgroup.freeze` file. It is reported as a controller so
-/// that the v1-style API can address it uniformly.
-const FREEZER_CONTROLLER: &str = "freezer";
-
 fn enable_controllers(controllers: &[String], path: &Path) {
     let f = path.join("cgroup.subtree_control");
     for c in controllers {
         // The freezer cannot be enabled through cgroup.subtree_control:
         // it is a core v2 feature and not a controller.
-        if c == FREEZER_CONTROLLER {
+        if c == &Controllers::Freezer.to_string() {
             continue;
         }
         let body = format!("+{}", c);
-        let _rest = fs::write(f.as_path(), body.as_bytes());
+        let _ = fs::write(f.as_path(), body.as_bytes());
     }
 }
 
-/// The controllers supported by the unified hierarchy, including the
-/// always-available freezer core functionality.
-fn supported_controllers() -> Vec<String> {
-    let p = format!("{}/{}", UNIFIED_MOUNTPOINT, "cgroup.controllers");
-    let ret = fs::read_to_string(p.as_str());
-    let mut controllers: Vec<String> = ret
-        .unwrap_or_default()
+/// The controllers reported by the unified hierarchy.
+fn supported_controllers(root: &Path) -> Result<Vec<String>> {
+    let path = root.join("cgroup.controllers");
+    let ret = fs::read_to_string(&path)
+        .map_err(|e| Error::with_cause(ErrorKind::ReadFailed(path.display().to_string()), e))?;
+    Ok(ret
         .split(' ')
         .map(|x| x.trim().to_string())
         .filter(|x| !x.is_empty())
-        .collect();
+        .collect())
+}
 
-    if !controllers.iter().any(|x| x == FREEZER_CONTROLLER) {
-        controllers.push(FREEZER_CONTROLLER.to_string());
+/// Checks static v2 controller availability, excluding the freezer core
+/// feature which is verified after creating the requested cgroup.
+fn specified_controllers_supported(
+    specified_controllers: &[String],
+    supported_controllers: &[String],
+) -> bool {
+    specified_controllers
+        .iter()
+        .filter(|controller| controller.as_str() != Controllers::Freezer.to_string())
+        .all(|controller| supported_controllers.contains(controller))
+}
+
+fn verify_specified_controllers(specified_controllers: &[String], root: &Path) -> bool {
+    let supported = supported_controllers(root).unwrap_or_default();
+    specified_controllers_supported(specified_controllers, &supported)
+}
+
+fn path_is_file(path: &Path) -> Result<bool> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.is_file()),
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                || e.kind() == std::io::ErrorKind::NotADirectory =>
+        {
+            Ok(false)
+        }
+        Err(e) => Err(Error::with_cause(
+            ErrorKind::ReadFailed(path.display().to_string()),
+            e,
+        )),
     }
-    controllers
+}
+
+/// Creates `path` unless it already names a directory.
+///
+/// Returns whether this call created the directory.
+fn create_dir_if_missing(path: &Path) -> Result<bool> {
+    match fs::create_dir(path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let metadata = fs::metadata(path).map_err(|metadata_error| {
+                Error::with_cause(
+                    ErrorKind::ReadFailed(path.display().to_string()),
+                    metadata_error,
+                )
+            })?;
+            if metadata.is_dir() {
+                Ok(false)
+            } else {
+                Err(Error::with_cause(ErrorKind::FsError, e))
+            }
+        }
+        Err(e) => Err(Error::with_cause(ErrorKind::FsError, e)),
+    }
 }
 
 fn create_v2_cgroup(
@@ -552,22 +597,57 @@ fn create_v2_cgroup(
 ) -> Result<()> {
     // controler list ["memory", "cpu"]
     let controllers = if let Some(s_controllers) = specified_controllers.clone() {
-        if verify_supported_controllers(s_controllers.as_ref()) {
+        if verify_specified_controllers(s_controllers.as_ref(), &root) {
             s_controllers
         } else {
             return Err(Error::new(ErrorKind::SpecifiedControllers));
         }
     } else {
-        supported_controllers()
+        supported_controllers(&root).unwrap_or_default()
     };
 
-    let mut fp = root;
-
-    // enable for root
-    enable_controllers(&controllers, &fp);
+    let freezer_check_required = specified_controllers
+        .as_ref()
+        .is_some_and(|cs| cs.iter().any(|c| c == &Controllers::Freezer.to_string()));
 
     // path: "a/b/c"
     let elements = path.split('/').collect::<Vec<&str>>();
+
+    if freezer_check_required {
+        let first = elements
+            .iter()
+            .copied()
+            .find(|element| !element.is_empty())
+            .ok_or_else(|| Error::new(ErrorKind::SpecifiedControllers))?;
+        let probe_path = root.join(first);
+        let probe_created = create_dir_if_missing(&probe_path)?;
+
+        let freezer_available = path_is_file(&probe_path.join("cgroup.freeze"));
+        match freezer_available {
+            Ok(true) => {}
+            Ok(false) => {
+                if probe_created {
+                    fs::remove_dir(&probe_path)
+                        .map_err(|e| Error::with_cause(ErrorKind::RemoveFailed, e))?;
+                }
+                return Err(Error::new(ErrorKind::SpecifiedControllers));
+            }
+            Err(e) => {
+                if probe_created {
+                    fs::remove_dir(&probe_path).map_err(|remove_error| {
+                        Error::with_cause(ErrorKind::RemoveFailed, remove_error)
+                    })?;
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    let mut fp = root;
+
+    // Enable controllers only after the freezer probe succeeds.
+    enable_controllers(&controllers, &fp);
+
     let last_index = elements.len() - 1;
     // Build up the directory hierarchy element by element, enabling the controllers for all
     // parents along the way.
@@ -588,14 +668,13 @@ fn create_v2_cgroup(
     Ok(())
 }
 
+/// Checks whether every non-freezer controller is reported by cgroup v2.
+///
+/// The freezer is a cgroup v2 core feature rather than a value reported by
+/// `cgroup.controllers`. Its availability is checked when the requested
+/// cgroup is created.
 pub fn verify_supported_controllers(controllers: &[String]) -> bool {
-    let sc = supported_controllers();
-    for controller in controllers.iter() {
-        if !sc.contains(controller) {
-            return false;
-        }
-    }
-    true
+    verify_specified_controllers(controllers, Path::new(UNIFIED_MOUNTPOINT))
 }
 
 pub fn get_cgroups_relative_paths() -> Result<HashMap<String, String>> {
@@ -652,4 +731,93 @@ fn get_cgroups_relative_paths_by_path(path: String) -> Result<HashMap<String, St
         }
     }
     Ok(m)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cgroups-rs-cgroup-test-{}-{}",
+            name,
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn freezer_only() -> Option<Vec<String>> {
+        Some(vec![Controllers::Freezer.to_string()])
+    }
+
+    #[test]
+    fn test_supported_controllers_reads_the_given_root() {
+        let root = temp_dir("controller-list");
+        std::fs::write(root.join("cgroup.controllers"), "cpu memory\n").unwrap();
+
+        assert_eq!(
+            supported_controllers(&root).unwrap(),
+            vec!["cpu".to_string(), "memory".to_string()]
+        );
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_specified_controllers_excludes_freezer_from_static_check() {
+        let freezer = Controllers::Freezer.to_string();
+        let cpu = "cpu".to_string();
+        let supported = vec![cpu.clone()];
+
+        assert!(specified_controllers_supported(
+            std::slice::from_ref(&freezer),
+            &[]
+        ));
+        assert!(specified_controllers_supported(
+            &[freezer.clone(), cpu.clone()],
+            &supported
+        ));
+        assert!(!specified_controllers_supported(&[freezer, cpu], &[]));
+    }
+
+    #[test]
+    fn test_v2_freezer_probe_cleans_up_created_cgroup() {
+        let root = temp_dir("freezer-probe-cleanup");
+        let error = create_v2_cgroup(root.clone(), "probe/leaf", &freezer_only()).unwrap_err();
+
+        assert_eq!(error.kind(), &ErrorKind::SpecifiedControllers);
+        assert!(!root.join("probe").exists());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_v2_freezer_probe_preserves_existing_cgroup() {
+        let root = temp_dir("freezer-probe-existing");
+        let probe = root.join("probe");
+        std::fs::create_dir(&probe).unwrap();
+
+        let error = create_v2_cgroup(root.clone(), "probe/leaf", &freezer_only()).unwrap_err();
+
+        assert_eq!(error.kind(), &ErrorKind::SpecifiedControllers);
+        assert!(probe.exists());
+        assert!(!probe.join("leaf").exists());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn test_v2_freezer_probe_accepts_cgroup_with_freezer_file() {
+        let root = temp_dir("freezer-probe-supported");
+        let probe = root.join("probe");
+        std::fs::create_dir(&probe).unwrap();
+        std::fs::write(probe.join("cgroup.freeze"), "0\n").unwrap();
+
+        create_v2_cgroup(root.clone(), "probe/leaf", &freezer_only()).unwrap();
+
+        assert!(probe.join("leaf").is_dir());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/src/fs/events.rs
+++ b/src/fs/events.rs
@@ -7,7 +7,7 @@ use nix::errno::Errno;
 use nix::sys::eventfd::{EfdFlags, EventFd};
 use nix::sys::inotify::{AddWatchFlags, InitFlags, Inotify};
 use std::fs::{self, File};
-use std::io::{BufRead, BufReader};
+use std::io::BufReader;
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver};
@@ -20,21 +20,9 @@ fn read_oom_count(path: &Path) -> Result<u64> {
     let file = File::open(path)
         .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
     let reader = BufReader::new(file);
-    for line in reader.lines() {
-        let line =
-            line.map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
-
-        let mut parts = line.split_whitespace();
-        if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
-            if key == "oom" {
-                let count: u64 = value
-                    .parse::<u64>()
-                    .map_err(|e| Error::with_cause(ParseError, e))?;
-                return Ok(count);
-            }
-        }
-    }
-    Err(Error::from_string("oom not found".to_string()))
+    let name = path.display().to_string();
+    crate::fs::read_keyed_u64(reader, "oom", &name)?
+        .ok_or_else(|| Error::from_string("oom not found".to_string()))
 }
 
 // notify_on_oom returns channel on which you can expect event about OOM,

--- a/src/fs/freezer.rs
+++ b/src/fs/freezer.rs
@@ -45,6 +45,10 @@ impl ControllerInternal for FreezerController {
         &self.base
     }
 
+    fn is_v2(&self) -> bool {
+        self.v2
+    }
+
     fn apply(&self, _res: &Resources) -> Result<()> {
         Ok(())
     }
@@ -130,5 +134,99 @@ impl FreezerController {
                 Err(e) => Err(Error::with_cause(ReadFailed(file_name.to_string()), e)),
             }
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "cgroups-rs-freezer-test-{}-{}",
+            name,
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn test_v1_state() {
+        let dir = temp_dir("v1-state");
+        let c = FreezerController::new(dir.clone(), dir.clone(), false);
+        assert!(!c.is_v2());
+
+        std::fs::write(dir.join("freezer.state"), "THAWED").unwrap();
+        assert_eq!(c.state().unwrap(), FreezerState::Thawed);
+
+        std::fs::write(dir.join("freezer.state"), "FROZEN").unwrap();
+        assert_eq!(c.state().unwrap(), FreezerState::Frozen);
+
+        std::fs::write(dir.join("freezer.state"), "FREEZING").unwrap();
+        assert_eq!(c.state().unwrap(), FreezerState::Freezing);
+
+        std::fs::write(dir.join("freezer.state"), "BOGUS").unwrap();
+        assert_eq!(c.state().unwrap_err().kind(), &ErrorKind::ParseError);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn test_v1_freeze_thaw() {
+        let dir = temp_dir("v1-freeze-thaw");
+        let c = FreezerController::new(dir.clone(), dir.clone(), false);
+
+        c.freeze().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("freezer.state")).unwrap(),
+            "FROZEN"
+        );
+
+        c.thaw().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("freezer.state")).unwrap(),
+            "THAWED"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn test_v2_state() {
+        let dir = temp_dir("v2-state");
+        let c = FreezerController::new(dir.clone(), dir.clone(), true);
+        assert!(c.is_v2());
+
+        std::fs::write(dir.join("cgroup.freeze"), "0").unwrap();
+        assert_eq!(c.state().unwrap(), FreezerState::Thawed);
+
+        std::fs::write(dir.join("cgroup.freeze"), "1").unwrap();
+        assert_eq!(c.state().unwrap(), FreezerState::Frozen);
+
+        std::fs::write(dir.join("cgroup.freeze"), "2").unwrap();
+        assert_eq!(c.state().unwrap_err().kind(), &ErrorKind::ParseError);
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn test_v2_freeze_thaw() {
+        let dir = temp_dir("v2-freeze-thaw");
+        let c = FreezerController::new(dir.clone(), dir.clone(), true);
+
+        c.freeze().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("cgroup.freeze")).unwrap(),
+            "1"
+        );
+
+        c.thaw().unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("cgroup.freeze")).unwrap(),
+            "0"
+        );
+
+        std::fs::remove_dir_all(dir).unwrap();
     }
 }

--- a/src/fs/freezer.rs
+++ b/src/fs/freezer.rs
@@ -8,13 +8,14 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/freezer-subsystem.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
-use std::io::{BufRead, BufReader, Read, Write};
+use std::io::{BufReader, Read, Write};
 use std::path::PathBuf;
 
 use crate::fs::error::ErrorKind::*;
 use crate::fs::error::*;
 use crate::fs::{
-    read_u64_from, ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem,
+    read_keyed_u64, read_u64_from, ControllIdentifier, ControllerInternal, Controllers, Resources,
+    Subsystem,
 };
 use crate::FreezerState;
 
@@ -136,20 +137,8 @@ impl FreezerController {
     fn read_frozen_counter(&self, file_name: &str) -> Result<u64> {
         self.open_path(file_name, false).and_then(|file| {
             let reader = BufReader::new(file);
-            for line in reader.lines() {
-                let line =
-                    line.map_err(|e| Error::with_cause(ReadFailed(file_name.to_string()), e))?;
-
-                let mut parts = line.split_whitespace();
-                if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
-                    if key == "frozen" {
-                        return value
-                            .parse::<u64>()
-                            .map_err(|e| Error::with_cause(ParseError, e));
-                    }
-                }
-            }
-            Err(Error::new(ErrorKind::ParseError))
+            read_keyed_u64(reader, "frozen", file_name)?
+                .ok_or_else(|| Error::new(ErrorKind::ParseError))
         })
     }
 

--- a/src/fs/freezer.rs
+++ b/src/fs/freezer.rs
@@ -8,12 +8,14 @@
 //!
 //! See the Kernel's documentation for more information about this subsystem, found at:
 //!  [Documentation/cgroup-v1/freezer-subsystem.txt](https://www.kernel.org/doc/Documentation/cgroup-v1/freezer-subsystem.txt)
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::path::PathBuf;
 
 use crate::fs::error::ErrorKind::*;
 use crate::fs::error::*;
-use crate::fs::{ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem};
+use crate::fs::{
+    read_u64_from, ControllIdentifier, ControllerInternal, Controllers, Resources, Subsystem,
+};
 use crate::FreezerState;
 
 /// A controller that allows controlling the `freezer` subsystem of a Cgroup.
@@ -113,12 +115,7 @@ impl FreezerController {
         })
     }
 
-    /// Retrieve the state of processes in the control group.
-    pub fn state(&self) -> Result<FreezerState> {
-        let mut file_name = "freezer.state";
-        if self.v2 {
-            file_name = "cgroup.freeze";
-        }
+    fn read_v1_state(&self, file_name: &str) -> Result<FreezerState> {
         self.open_path(file_name, false).and_then(|mut file| {
             let mut s = String::new();
             let res = file.read_to_string(&mut s);
@@ -134,6 +131,53 @@ impl FreezerController {
                 Err(e) => Err(Error::with_cause(ReadFailed(file_name.to_string()), e)),
             }
         })
+    }
+
+    fn read_frozen_counter(&self, file_name: &str) -> Result<u64> {
+        self.open_path(file_name, false).and_then(|file| {
+            let reader = BufReader::new(file);
+            for line in reader.lines() {
+                let line =
+                    line.map_err(|e| Error::with_cause(ReadFailed(file_name.to_string()), e))?;
+
+                let mut parts = line.split_whitespace();
+                if let (Some(key), Some(value)) = (parts.next(), parts.next()) {
+                    if key == "frozen" {
+                        return value
+                            .parse::<u64>()
+                            .map_err(|e| Error::with_cause(ParseError, e));
+                    }
+                }
+            }
+            Err(Error::new(ErrorKind::ParseError))
+        })
+    }
+
+    /// Retrieve the state of processes in the control group.
+    ///
+    /// On cgroup v2, this reflects the kernel's actual state by combining
+    /// `cgroup.freeze` (the requested state) with `cgroup.events` (the
+    /// completed state). As a result, it may transiently return
+    /// [`FreezerState::Freezing`] immediately after [`freeze`](Self::freeze)
+    /// (before the kernel finishes freezing) or
+    /// [`FreezerState::Frozen`] immediately after [`thaw`](Self::thaw)
+    /// (before the kernel updates `cgroup.events`). Poll `state()` if you
+    /// need to observe the final state.
+    pub fn state(&self) -> Result<FreezerState> {
+        if !self.v2 {
+            return self.read_v1_state("freezer.state");
+        }
+
+        let requested = self
+            .open_path("cgroup.freeze", false)
+            .and_then(read_u64_from)?;
+        let completed = self.read_frozen_counter("cgroup.events")?;
+        match (requested, completed) {
+            (1, 1) | (0, 1) => Ok(FreezerState::Frozen),
+            (1, 0) => Ok(FreezerState::Freezing),
+            (0, 0) => Ok(FreezerState::Thawed),
+            _ => Err(Error::new(ErrorKind::ParseError)),
+        }
     }
 }
 
@@ -199,9 +243,13 @@ mod test {
         assert!(c.is_v2());
 
         std::fs::write(dir.join("cgroup.freeze"), "0").unwrap();
+        std::fs::write(dir.join("cgroup.events"), "frozen 0").unwrap();
         assert_eq!(c.state().unwrap(), FreezerState::Thawed);
 
         std::fs::write(dir.join("cgroup.freeze"), "1").unwrap();
+        assert_eq!(c.state().unwrap(), FreezerState::Freezing);
+
+        std::fs::write(dir.join("cgroup.events"), "frozen 1").unwrap();
         assert_eq!(c.state().unwrap(), FreezerState::Frozen);
 
         std::fs::write(dir.join("cgroup.freeze"), "2").unwrap();

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -993,3 +993,24 @@ fn read_u64_from(file: File) -> Result<u64> {
 fn read_i64_from(file: File) -> Result<i64> {
     read_from::<i64>(file)
 }
+
+/// Read a single `key value` line from a keyed cgroup file (e.g.
+/// `cgroup.events`, `memory.events`) and parse the value as u64.
+///
+/// Returns `Ok(Some(n))` if the key was found, `Ok(None)` if the key was
+/// absent. `file_name` is used in read-error messages for diagnostics.
+fn read_keyed_u64(reader: impl BufRead, key: &str, file_name: &str) -> Result<Option<u64>> {
+    for line in reader.lines() {
+        let line = line.map_err(|e| Error::with_cause(ReadFailed(file_name.to_string()), e))?;
+        let mut parts = line.split_whitespace();
+        if let (Some(k), Some(v)) = (parts.next(), parts.next()) {
+            if k == key {
+                let n = v
+                    .parse::<u64>()
+                    .map_err(|e| Error::with_cause(ParseError, e))?;
+                return Ok(Some(n));
+            }
+        }
+    }
+    Ok(None)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub const CPU_SHARES_V1_MAX: u64 = 262144;
 pub const CPU_WEIGHT_V2_MAX: u64 = 10000;
 
 /// The current state of the control group
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FreezerState {
     /// The processes in the control group are _not_ frozen.

--- a/tests/freezer.rs
+++ b/tests/freezer.rs
@@ -1,0 +1,121 @@
+// Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
+//! Integration tests for the freezer controller on both cgroup versions.
+//!
+//! These tests move a forked child process into the cgroup and freeze it,
+//! keeping the test process itself outside so it can thaw the child again.
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use nix::unistd::{fork, ForkResult};
+
+use cgroups_rs::fs::freezer::FreezerController;
+use cgroups_rs::fs::Cgroup;
+use cgroups_rs::{CgroupPid, FreezerState};
+
+/// Polls the freezer state until it reaches the expected value, tolerating
+/// transient states such as `Freezing`.
+fn wait_for_state(freezer: &FreezerController, expected: FreezerState) {
+    for _ in 0..100 {
+        if freezer.state().unwrap() == expected {
+            return;
+        }
+        sleep(Duration::from_millis(10));
+    }
+    assert_eq!(freezer.state().unwrap(), expected);
+}
+
+/// Moves `task` into the cgroup, freezes it, verifies the state, thaws it
+/// and moves the task back out.
+///
+/// On v2 the task is moved through `cgroup.procs` (`add_task_by_tgid`),
+/// because `add_task` writes `cgroup.threads`, which is only writable in
+/// threaded mode. On v1 the issue's original `add_task` flow is used.
+fn freeze_and_thaw(cg: &Cgroup, task: u64) {
+    let freezer: &FreezerController = cg.controller_of().expect("freezer controller not found");
+    let task = CgroupPid::from(task);
+
+    if cg.v2() {
+        cg.add_task_by_tgid(task).unwrap();
+    } else {
+        cg.add_task(task).unwrap();
+    }
+    freezer.freeze().unwrap();
+    wait_for_state(freezer, FreezerState::Frozen);
+    freezer.thaw().unwrap();
+    wait_for_state(freezer, FreezerState::Thawed);
+    if cg.v2() {
+        cg.remove_task_by_tgid(task).unwrap();
+    } else {
+        cg.remove_task(task).unwrap();
+    }
+}
+
+/// Forks a child that just sleeps, runs `f` in the parent, then kills and
+/// reaps the child.
+fn with_sleeping_child(f: impl FnOnce(u64)) {
+    match unsafe { fork() }.unwrap() {
+        ForkResult::Child => {
+            sleep(Duration::from_secs(60));
+            std::process::exit(0);
+        }
+        ForkResult::Parent { child } => {
+            f(child.as_raw() as u64);
+            unsafe {
+                libc::kill(child.as_raw(), libc::SIGKILL);
+                libc::waitpid(child.as_raw(), std::ptr::null_mut(), 0);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_freezer_v2_specified_controllers() {
+    if !cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+
+    // Regression test for issue #124: creating a v2 cgroup with only the
+    // freezer controller specified must succeed, even though the kernel
+    // does not list freezer in cgroup.controllers.
+    let cg = Cgroup::new_with_specified_controllers(
+        cgroups_rs::fs::hierarchies::auto(),
+        String::from("test_freezer_v2_specified_controllers"),
+        Some(vec![String::from("freezer")]),
+    )
+    .unwrap();
+
+    with_sleeping_child(|pid| {
+        freeze_and_thaw(&cg, pid);
+    });
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_freezer_v1_freeze_thaw() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+
+    let cg = Cgroup::new(
+        cgroups_rs::fs::hierarchies::auto(),
+        String::from("test_freezer_v1_freeze_thaw"),
+    )
+    .unwrap();
+
+    // Skip when the freezer subsystem is not mounted on this host.
+    if cg.controller_of::<FreezerController>().is_none() {
+        cg.delete().unwrap();
+        return;
+    }
+
+    with_sleeping_child(|pid| {
+        freeze_and_thaw(&cg, pid);
+    });
+    cg.delete().unwrap();
+}

--- a/tests/freezer.rs
+++ b/tests/freezer.rs
@@ -13,6 +13,7 @@ use std::process::{Child, Command};
 use std::thread::sleep;
 use std::time::Duration;
 
+use cgroups_rs::fs::error::ErrorKind;
 use cgroups_rs::fs::freezer::FreezerController;
 use cgroups_rs::fs::Cgroup;
 use cgroups_rs::{CgroupPid, FreezerState};
@@ -55,25 +56,35 @@ fn freeze_and_thaw(cg: &Cgroup, task: u64) {
     }
 }
 
-struct ChildGuard(Child);
+struct ChildGuard<'a> {
+    child: Child,
+    cgroup: &'a Cgroup,
+}
 
-impl Drop for ChildGuard {
+impl<'a> Drop for ChildGuard<'a> {
     fn drop(&mut self) {
-        let _ = self.0.kill();
-        let _ = self.0.wait();
+        // A task frozen by the v1 (or v2) freezer ignores SIGKILL, so a
+        // panic that leaves the child frozen would make `wait()` block
+        // until the CI timeout. Thaw the cgroup best-effort first; on an
+        // already-thawed cgroup `thaw()` is an idempotent no-op write.
+        if let Some(freezer) = self.cgroup.controller_of::<FreezerController>() {
+            let _ = freezer.thaw();
+        }
+        let _ = self.child.kill();
+        let _ = self.child.wait();
     }
 }
 
 /// Forks a child that just sleeps, runs `f` in the parent, then kills and
 /// reaps the child.
-fn with_sleeping_child(f: impl FnOnce(u64)) {
+fn with_sleeping_child(cg: &Cgroup, f: impl FnOnce(u64)) {
     let child = Command::new("sleep")
         .arg("60")
         .spawn()
         .expect("Failed to spawn sleep process");
 
-    let guard = ChildGuard(child);
-    f(guard.0.id() as u64);
+    let guard = ChildGuard { child, cgroup: cg };
+    f(guard.child.id() as u64);
 }
 
 #[test]
@@ -85,14 +96,17 @@ fn test_freezer_v2_specified_controllers() {
     // Regression test for issue #124: creating a v2 cgroup with only the
     // freezer controller specified must succeed, even though the kernel
     // does not list freezer in cgroup.controllers.
-    let cg = Cgroup::new_with_specified_controllers(
+    let cg = match Cgroup::new_with_specified_controllers(
         cgroups_rs::fs::hierarchies::auto(),
         String::from("test_freezer_v2_specified_controllers"),
         Some(vec![String::from("freezer")]),
-    )
-    .unwrap();
+    ) {
+        Ok(cg) => cg,
+        Err(e) if e.kind() == &ErrorKind::SpecifiedControllers => return,
+        Err(e) => panic!("failed to create v2 cgroup: {}", e),
+    };
 
-    with_sleeping_child(|pid| {
+    with_sleeping_child(&cg, |pid| {
         freeze_and_thaw(&cg, pid);
     });
     cg.delete().unwrap();
@@ -116,7 +130,7 @@ fn test_freezer_v1_freeze_thaw() {
         return;
     }
 
-    with_sleeping_child(|pid| {
+    with_sleeping_child(&cg, |pid| {
         freeze_and_thaw(&cg, pid);
     });
     cg.delete().unwrap();

--- a/tests/freezer.rs
+++ b/tests/freezer.rs
@@ -1,0 +1,123 @@
+// Copyright (c) 2018 Levente Kurusa
+// Copyright (c) 2020 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
+//! Integration tests for the freezer controller on both cgroup versions.
+//!
+//! These tests move a forked child process into the cgroup and freeze it,
+//! keeping the test process itself outside so it can thaw the child again.
+
+use std::process::{Child, Command};
+use std::thread::sleep;
+use std::time::Duration;
+
+use cgroups_rs::fs::freezer::FreezerController;
+use cgroups_rs::fs::Cgroup;
+use cgroups_rs::{CgroupPid, FreezerState};
+
+/// Polls the freezer state until it reaches the expected value, tolerating
+/// transient states such as `Freezing`.
+fn wait_for_state(freezer: &FreezerController, expected: FreezerState) {
+    for _ in 0..100 {
+        if freezer.state().unwrap() == expected {
+            return;
+        }
+        sleep(Duration::from_millis(10));
+    }
+    assert_eq!(freezer.state().unwrap(), expected);
+}
+
+/// Moves `task` into the cgroup, freezes it, verifies the state, thaws it
+/// and moves the task back out.
+///
+/// On v2 the task is moved through `cgroup.procs` (`add_task_by_tgid`),
+/// because `add_task` writes `cgroup.threads`, which is only writable in
+/// threaded mode. On v1 the issue's original `add_task` flow is used.
+fn freeze_and_thaw(cg: &Cgroup, task: u64) {
+    let freezer: &FreezerController = cg.controller_of().expect("freezer controller not found");
+    let task = CgroupPid::from(task);
+
+    if cg.v2() {
+        cg.add_task_by_tgid(task).unwrap();
+    } else {
+        cg.add_task(task).unwrap();
+    }
+    freezer.freeze().unwrap();
+    wait_for_state(freezer, FreezerState::Frozen);
+    freezer.thaw().unwrap();
+    wait_for_state(freezer, FreezerState::Thawed);
+    if cg.v2() {
+        cg.remove_task_by_tgid(task).unwrap();
+    } else {
+        cg.remove_task(task).unwrap();
+    }
+}
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Forks a child that just sleeps, runs `f` in the parent, then kills and
+/// reaps the child.
+fn with_sleeping_child(f: impl FnOnce(u64)) {
+    let child = Command::new("sleep")
+        .arg("60")
+        .spawn()
+        .expect("Failed to spawn sleep process");
+
+    let guard = ChildGuard(child);
+    f(guard.0.id() as u64);
+}
+
+#[test]
+fn test_freezer_v2_specified_controllers() {
+    if !cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+
+    // Regression test for issue #124: creating a v2 cgroup with only the
+    // freezer controller specified must succeed, even though the kernel
+    // does not list freezer in cgroup.controllers.
+    let cg = Cgroup::new_with_specified_controllers(
+        cgroups_rs::fs::hierarchies::auto(),
+        String::from("test_freezer_v2_specified_controllers"),
+        Some(vec![String::from("freezer")]),
+    )
+    .unwrap();
+
+    with_sleeping_child(|pid| {
+        freeze_and_thaw(&cg, pid);
+    });
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_freezer_v1_freeze_thaw() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+
+    let cg = Cgroup::new(
+        cgroups_rs::fs::hierarchies::auto(),
+        String::from("test_freezer_v1_freeze_thaw"),
+    )
+    .unwrap();
+
+    // Skip when the freezer subsystem is not mounted on this host.
+    if cg.controller_of::<FreezerController>().is_none() {
+        cg.delete().unwrap();
+        return;
+    }
+
+    with_sleeping_child(|pid| {
+        freeze_and_thaw(&cg, pid);
+    });
+    cg.delete().unwrap();
+}


### PR DESCRIPTION
The freezer is a core v2 feature (cgroup.freeze) rather than a controller, so it is absent from cgroup.controllers. Creating a v2 cgroup with the freezer controller specified failed with ErrorKind::SpecifiedControllers (issue #124).

Report the freezer as an always-supported v2 controller in supported_controllers(), skip it when enabling controllers through cgroup.subtree_control, and centralize the fake-controller logic in the shared FREEZER_CONTROLLER constant.

Also add the missing FreezerController::is_v2() override, which every other v2-capable controller has and whose absence caused ErrorKind::CgroupVersion on v2 membership operations.

Add unit tests covering v1/v2 freeze, thaw and state parsing, and add an integration test reproducing the issue #124 flow on v2, and a v1 freeze/thaw integration test for basic coverage.

Fixes https://github.com/kata-containers/cgroups-rs/issues/124.