### PR TITLE
build: bump nix dependency from 0.25 to 0.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 async-io = "2"
 futures-lite = "2"
 log = "0.4"
-nix = { version = "0.25.0", default-features = false, features = ["event", "fs", "process"] }
+nix = { version = "0.31", default-features = false, features = ["event", "fs", "process", "signal"] }
 libc = "0.2"
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1"
@@ -26,7 +26,7 @@ bit-vec = "0.6"
 [dev-dependencies]
 libc = "0.2.76"
 rand = "0.8"
-nix = "0.25"
+nix = "0.31"
 
 [features]
 default = []

--- a/src/fs/events.rs
+++ b/src/fs/events.rs
@@ -3,11 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0 or MIT
 //
 
-use eventfd::{eventfd, EfdFlags};
-use nix::sys::eventfd;
+use nix::sys::eventfd::{EfdFlags, EventFd};
 use std::fs::{self, File};
-use std::io::Read;
-use std::os::unix::io::{AsRawFd, FromRawFd};
+use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::mpsc::{self, Receiver};
 use std::thread;
@@ -49,14 +47,14 @@ fn register_memory_event(
     let event_file = File::open(path.clone())
         .map_err(|e| Error::with_cause(ReadFailed(path.display().to_string()), e))?;
 
-    let eventfd = eventfd(0, EfdFlags::EFD_CLOEXEC)
+    let eventfd = EventFd::from_flags(EfdFlags::EFD_CLOEXEC)
         .map_err(|e| Error::with_cause(ReadFailed("eventfd".to_string()), e))?;
 
     let event_control_path = cg_dir.join("cgroup.event_control");
     let data = if arg.is_empty() {
-        format!("{} {}", eventfd, event_file.as_raw_fd())
+        format!("{} {}", eventfd.as_raw_fd(), event_file.as_raw_fd())
     } else {
-        format!("{} {} {}", eventfd, event_file.as_raw_fd(), arg)
+        format!("{} {} {}", eventfd.as_raw_fd(), event_file.as_raw_fd(), arg)
     };
 
     // write to file and set mode to 0700(FIXME)
@@ -67,15 +65,12 @@ fn register_memory_event(
         )
     })?;
 
-    let mut eventfd_file = unsafe { File::from_raw_fd(eventfd) };
-
     let (sender, receiver) = mpsc::channel();
     let key = key.to_string();
 
     thread::spawn(move || {
         loop {
-            let mut buf = [0; 8];
-            if eventfd_file.read(&mut buf).is_err() {
+            if eventfd.read().is_err() {
                 return;
             }
 


### PR DESCRIPTION
Bump nix to 0.31 and migrate memory event registration to the EventFd API. Keep the descriptor owned by the listener thread and remove the unsafe File::from_raw_fd conversion.

Closes https://github.com/kata-containers/cgroups-rs/issues/165.