### PR TITLE
cpu: add CFS burst support

### DIFF
--- a/src/fs/cgroup_builder.rs
+++ b/src/fs/cgroup_builder.rs
@@ -230,6 +230,7 @@ impl CpuResourceBuilder {
     gen_setter!(cpu, CpuController, set_shares, shares, u64);
     gen_setter!(cpu, CpuController, set_cfs_quota, quota, i64);
     gen_setter!(cpu, CpuController, set_cfs_period, period, u64);
+    gen_setter!(cpu, CpuController, set_cfs_burst, burst, u64);
     gen_setter!(cpu, CpuController, set_rt_runtime, realtime_runtime, i64);
     gen_setter!(cpu, CpuController, set_rt_period, realtime_period, u64);
 

--- a/src/fs/cpu.rs
+++ b/src/fs/cpu.rs
@@ -78,6 +78,7 @@ impl ControllerInternal for CpuController {
         update_and_test!(self, set_shares, res.shares, shares);
         update_and_test!(self, set_cfs_period, res.period, cfs_period);
         update_and_test!(self, set_cfs_quota, res.quota, cfs_quota);
+        update_and_test!(self, set_cfs_burst, res.burst, cfs_burst);
 
         res.attrs.iter().for_each(|(k, v)| {
             let _ = self.set(k, v);
@@ -296,6 +297,38 @@ impl CpuController {
                     )
                 })
             })
+    }
+
+    pub fn set_cfs_burst(&self, us: u64) -> Result<()> {
+        if self.v2 {
+            return self.open_path("cpu.max.burst", true).and_then(|mut file| {
+                file.write_all(us.to_string().as_ref()).map_err(|e| {
+                    Error::with_cause(WriteFailed("cpu.max.burst".to_string(), us.to_string()), e)
+                })
+            });
+        }
+        self.open_path("cpu.cfs_burst_us", true)
+            .and_then(|mut file| {
+                file.write_all(us.to_string().as_ref()).map_err(|e| {
+                    Error::with_cause(
+                        WriteFailed("cpu.cfs_burst_us".to_string(), us.to_string()),
+                        e,
+                    )
+                })
+            })
+    }
+
+    pub fn cfs_burst(&self) -> Result<u64> {
+        if self.v2 {
+            let current_value = self
+                .open_path("cpu.max.burst", false)
+                .and_then(read_u64_from)?;
+            return Ok(current_value);
+        }
+        let current_value = self
+            .open_path("cpu.cfs_burst_us", false)
+            .and_then(read_u64_from)?;
+        Ok(current_value)
     }
 }
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -599,6 +599,8 @@ pub struct CpuResources {
     pub quota: Option<i64>,
     /// Period of time in microseconds.
     pub period: Option<u64>,
+    /// cgroup v2 = `cpu.max.burst`,v1 = `cpu.cfs_burst_us`.
+    pub burst: Option<u64>,
     /// This is currently a no-operation.
     pub realtime_runtime: Option<i64>,
     /// This is currently a no-operation.

--- a/src/manager/fs.rs
+++ b/src/manager/fs.rs
@@ -163,6 +163,10 @@ impl FsManager {
             controller.set_cfs_period(period)?;
         }
 
+        if let Some(burst) = linux_cpu.burst() {
+            controller.set_cfs_burst(burst)?;
+        }
+
         if let Some(rt_runtime) = linux_cpu.realtime_runtime() {
             controller.set_rt_runtime(rt_runtime)?;
         }

--- a/src/manager/systemd.rs
+++ b/src/manager/systemd.rs
@@ -147,6 +147,10 @@ impl SystemdManager<'_> {
             props.push((id, value.into()));
         }
 
+        // TODO: burst (cpu.max.burst / cpu.cfs_burst_us) and rt properties
+        // (realtime_runtime / realtime_period) are not yet supported, as
+        // systemd does not expose corresponding D-Bus properties for them.
+
         Ok(())
     }
 

--- a/tests/cpu.rs
+++ b/tests/cpu.rs
@@ -59,3 +59,36 @@ fn test_cfs_quota_and_periods() {
 
     cg.delete().unwrap();
 }
+
+#[test]
+fn test_cfs_burst() {
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let cg = Cgroup::new(h, String::from("test_cfs_burst")).unwrap();
+
+    let cpu_controller: &CpuController = cg.controller_of().unwrap();
+
+    // The default burst is 0 on both v1 (cpu.cfs_burst_us) and v2
+    // (cpu.max.burst). Skip on kernels without burst support (the file
+    // does not exist on kernels < 5.14).
+    if cpu_controller.cfs_burst().is_err() {
+        eprintln!("skipping test_cfs_burst: cpu.max.burst not supported");
+        cg.delete().unwrap();
+        return;
+    }
+
+    // verify default value
+    let current_burst = cpu_controller.cfs_burst().unwrap();
+    assert_eq!(0, current_burst);
+
+    // case 1 set burst
+    cpu_controller.set_cfs_burst(100000).unwrap();
+    let current_burst = cpu_controller.cfs_burst().unwrap();
+    assert_eq!(100000, current_burst);
+
+    // case 2 reset burst to 0
+    cpu_controller.set_cfs_burst(0).unwrap();
+    let current_burst = cpu_controller.cfs_burst().unwrap();
+    assert_eq!(0, current_burst);
+
+    cg.delete().unwrap();
+}


### PR DESCRIPTION
Add support for the CFS burst buffer on both cgroup v2 (cpu.max.burst, kernel >= 5.14) and v1 (cpu.cfs_burst_us).

Fixes https://github.com/kata-containers/cgroups-rs/issues/151.