### PR TITLE
fs: add tasks to a subset of subsystems on cgroup v1

### DIFF
--- a/src/fs/cgroup.rs
+++ b/src/fs/cgroup.rs
@@ -10,7 +10,9 @@ use crate::fs::error::ErrorKind::*;
 use crate::fs::error::*;
 
 use crate::fs::hierarchies::V1;
-use crate::fs::{CgroupPid, ControllIdentifier, Controller, Hierarchy, Resources, Subsystem};
+use crate::fs::{
+    CgroupPid, ControllIdentifier, Controller, Controllers, Hierarchy, Resources, Subsystem,
+};
 
 use std::collections::HashMap;
 use std::convert::From;
@@ -396,6 +398,66 @@ impl Cgroup {
                 .iter()
                 .try_for_each(|sub| sub.to_controller().add_task_by_tgid(&tgid))
         }
+    }
+
+    /// Attach a task to a subset of subsystems in the control group.
+    ///
+    /// This is only supported on cgroup v1 where controllers reside in independent hierarchies.
+    pub fn add_task_to_subsystems(&self, tid: CgroupPid, subsystems: &[Controllers]) -> Result<()> {
+        if self.v2() {
+            return Err(Error::new(CgroupVersion));
+        }
+        if subsystems.is_empty() {
+            return Err(Error::new(SubsystemsEmpty));
+        }
+        let targets: Vec<&Subsystem> = self
+            .subsystems()
+            .iter()
+            .filter(|s| subsystems.contains(&s.to_controller().control_type()))
+            .collect();
+        for requested in subsystems {
+            if !targets
+                .iter()
+                .any(|s| s.to_controller().control_type() == *requested)
+            {
+                return Err(Error::new(SpecifiedControllers));
+            }
+        }
+        targets
+            .iter()
+            .try_for_each(|sub| sub.to_controller().add_task(&tid))
+    }
+
+    /// Attach tasks to a subset of subsystems in the control group by thread group id.
+    ///
+    /// This is only supported on cgroup v1 where controllers reside in independent hierarchies.
+    pub fn add_task_by_tgid_to_subsystems(
+        &self,
+        tgid: CgroupPid,
+        subsystems: &[Controllers],
+    ) -> Result<()> {
+        if self.v2() {
+            return Err(Error::new(CgroupVersion));
+        }
+        if subsystems.is_empty() {
+            return Err(Error::new(SubsystemsEmpty));
+        }
+        let targets: Vec<&Subsystem> = self
+            .subsystems()
+            .iter()
+            .filter(|s| subsystems.contains(&s.to_controller().control_type()))
+            .collect();
+        for requested in subsystems {
+            if !targets
+                .iter()
+                .any(|s| s.to_controller().control_type() == *requested)
+            {
+                return Err(Error::new(SpecifiedControllers));
+            }
+        }
+        targets
+            .iter()
+            .try_for_each(|sub| sub.to_controller().add_task_by_tgid(&tgid))
     }
 
     /// set cgroup.type

--- a/tests/cgroup.rs
+++ b/tests/cgroup.rs
@@ -13,9 +13,9 @@ use cgroups_rs::fs::cgroup::{
     CGROUP_MODE_DOMAIN, CGROUP_MODE_DOMAIN_INVALID, CGROUP_MODE_DOMAIN_THREADED,
     CGROUP_MODE_THREADED,
 };
+use cgroups_rs::fs::error::ErrorKind;
 use cgroups_rs::fs::memory::MemController;
-use cgroups_rs::fs::Controller;
-use cgroups_rs::fs::{Cgroup, Subsystem};
+use cgroups_rs::fs::{Cgroup, Controller, Controllers, Subsystem};
 use cgroups_rs::CgroupPid;
 
 #[test]
@@ -271,5 +271,214 @@ fn test_cgroup_v2() {
     println!("memswap {:?}", memswap);
     assert_eq!(swp, memswap.limit_in_bytes);
 
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_add_task_by_tgid_to_subsystems_v1() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let pid = libc::pid_t::from(nix::unistd::getpid()) as u64;
+    let cg = Cgroup::new(h, String::from("test_add_task_by_tgid_to_subsystems_v1")).unwrap();
+    {
+        // Attach the current process only to the memory subsystem.
+        cg.add_task_by_tgid_to_subsystems(CgroupPid::from(pid), &[Controllers::Mem])
+            .unwrap();
+
+        // Verify the pid landed in the memory subsystem but not in any other
+        // attached subsystem of this control group.
+        for sub in cg.subsystems() {
+            let procs = sub.to_controller().procs();
+            match sub {
+                Subsystem::Mem(_) => assert!(
+                    procs.contains(&CgroupPid::from(pid)),
+                    "pid not in memory subsystem after subset attach"
+                ),
+                _ => assert!(
+                    !procs.contains(&CgroupPid::from(pid)),
+                    "pid unexpectedly attached to a non-memory subsystem"
+                ),
+            }
+        }
+
+        // Move the process back to the root cgroup before cleanup.
+        cg.remove_task_by_tgid(CgroupPid::from(pid)).unwrap();
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_add_task_to_subsystems_v1() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let pid = libc::pid_t::from(nix::unistd::getpid()) as u64;
+    let cg = Cgroup::new(h, String::from("test_add_task_to_subsystems_v1")).unwrap();
+    {
+        // Attach the current thread only to the memory subsystem.
+        cg.add_task_to_subsystems(CgroupPid::from(pid), &[Controllers::Mem])
+            .unwrap();
+
+        for sub in cg.subsystems() {
+            let tasks = sub.to_controller().tasks();
+            match sub {
+                Subsystem::Mem(_) => assert!(
+                    tasks.contains(&CgroupPid::from(pid)),
+                    "tid not in memory subsystem after subset attach"
+                ),
+                _ => assert!(
+                    !tasks.contains(&CgroupPid::from(pid)),
+                    "tid unexpectedly attached to a non-memory subsystem"
+                ),
+            }
+        }
+
+        cg.remove_task(CgroupPid::from(pid)).unwrap();
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_add_task_to_subsystems_empty_v1() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let cg = Cgroup::new(h, String::from("test_add_task_to_subsystems_empty_v1")).unwrap();
+    {
+        // An empty subsystem filter must fail before any write.
+        let err = cg
+            .add_task_to_subsystems(CgroupPid::from(1), &[])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::SubsystemsEmpty);
+
+        let err = cg
+            .add_task_by_tgid_to_subsystems(CgroupPid::from(1), &[])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::SubsystemsEmpty);
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_add_task_to_subsystems_no_match_v1() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+    let h = cgroups_rs::fs::hierarchies::auto();
+    // Build a cgroup that only attaches the memory subsystem, then request a
+    // controller (cpu) that is not attached to it.
+    let cg = Cgroup::new_with_specified_controllers(
+        h,
+        String::from("test_add_task_to_subsystems_no_match_v1"),
+        Some(vec![String::from("memory")]),
+    )
+    .unwrap();
+    {
+        let err = cg
+            .add_task_by_tgid_to_subsystems(CgroupPid::from(1), &[Controllers::Cpu])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::SpecifiedControllers);
+
+        let err = cg
+            .add_task_to_subsystems(CgroupPid::from(1), &[Controllers::Cpu])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::SpecifiedControllers);
+
+        // A partial mismatch (e.g. Mem exists, but Cpu does not) must also fail.
+        let err = cg
+            .add_task_to_subsystems(CgroupPid::from(1), &[Controllers::Mem, Controllers::Cpu])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::SpecifiedControllers);
+
+        let err = cg
+            .add_task_to_subsystems(CgroupPid::from(1), &[Controllers::Mem, Controllers::Cpu])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::SpecifiedControllers);
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_add_task_to_subsystems_v2_unsupported() {
+    if !cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let cg = Cgroup::new(
+        h,
+        String::from("test_add_task_to_subsystems_v2_unsupported"),
+    )
+    .unwrap();
+    {
+        let pid = libc::pid_t::from(nix::unistd::getpid()) as u64;
+        // On cgroup v2 a subsystem subset is meaningless; the unified
+        // hierarchy must be rejected rather than silently attaching.
+        let err = cg
+            .add_task_to_subsystems(CgroupPid::from(pid), &[Controllers::Mem])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::CgroupVersion);
+
+        let err = cg
+            .add_task_by_tgid_to_subsystems(CgroupPid::from(pid), &[Controllers::Mem])
+            .unwrap_err();
+        assert_eq!(err.kind(), &ErrorKind::CgroupVersion);
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+fn test_add_task_to_subsystems_dedup_v1() {
+    if cgroups_rs::fs::hierarchies::is_cgroup2_unified_mode() {
+        return;
+    }
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let pid = libc::pid_t::from(nix::unistd::getpid()) as u64;
+    let cg = Cgroup::new(h, String::from("test_add_task_to_subsystems_dedup_v1")).unwrap();
+    {
+        // A repeated request for the same controller must be deduped: it must
+        // not error (a length-based check would misfire) and must attach
+        // exactly once to the memory subsystem.
+        cg.add_task_to_subsystems(CgroupPid::from(pid), &[Controllers::Mem, Controllers::Mem])
+            .unwrap();
+        for sub in cg.subsystems() {
+            let tasks = sub.to_controller().tasks();
+            match sub {
+                Subsystem::Mem(_) => assert!(
+                    tasks.contains(&CgroupPid::from(pid)),
+                    "tid not in memory subsystem after deduped attach"
+                ),
+                _ => assert!(
+                    !tasks.contains(&CgroupPid::from(pid)),
+                    "tid unexpectedly attached to a non-memory subsystem"
+                ),
+            }
+        }
+        cg.remove_task(CgroupPid::from(pid)).unwrap();
+
+        // Same contract for the tgid variant.
+        cg.add_task_by_tgid_to_subsystems(
+            CgroupPid::from(pid),
+            &[Controllers::Mem, Controllers::Mem],
+        )
+        .unwrap();
+        for sub in cg.subsystems() {
+            let procs = sub.to_controller().procs();
+            match sub {
+                Subsystem::Mem(_) => assert!(
+                    procs.contains(&CgroupPid::from(pid)),
+                    "pid not in memory subsystem after deduped attach"
+                ),
+                _ => assert!(
+                    !procs.contains(&CgroupPid::from(pid)),
+                    "pid unexpectedly attached to a non-memory subsystem"
+                ),
+            }
+        }
+        cg.remove_task_by_tgid(CgroupPid::from(pid)).unwrap();
+    }
     cg.delete().unwrap();
 }


### PR DESCRIPTION
Add `Cgroup::add_task_to_subsystems` and
`add_task_by_tgid_to_subsystems` so a process or thread can be placed into a subset of the cgroup's subsystems instead of all of them. In cgroup v1 each subsystem is an independent hierarchy, so a process may legitimately reside in different cgroups per subsystem; this lets callers constrain a process to specific controllers (e.g. hugetlb) while leaving others untouched.

Fixes https://github.com/kata-containers/cgroups-rs/issues/95.