### PR TITLE
fs: Add support for the misc cgroup controller

### DIFF
--- a/src/fs/cgroup.rs
+++ b/src/fs/cgroup.rs
@@ -260,6 +260,7 @@ impl Cgroup {
             Subsystem::NetPrio(c) => c.delete(),
             Subsystem::HugeTlb(c) => c.delete(),
             Subsystem::Rdma(c) => c.delete(),
+            Subsystem::Misc(c) => c.delete(),
             Subsystem::Systemd(c) => c.delete(),
         })
     }

--- a/src/fs/cgroup_builder.rs
+++ b/src/fs/cgroup_builder.rs
@@ -62,7 +62,7 @@
 
 use crate::fs::{
     BlkIoDeviceResource, BlkIoDeviceThrottleResource, Cgroup, DeviceResource, Error, Hierarchy,
-    HugePageResource, MaxValue, NetworkPriority, Resources,
+    HugePageResource, MaxValue, MiscMaxValue, NetworkPriority, Resources,
 };
 
 macro_rules! gen_setter {
@@ -134,6 +134,11 @@ impl CgroupBuilder {
             cgroup: self,
             throttling_iops: false,
         }
+    }
+
+    /// Builds the misc resources available for the control group.
+    pub fn misc(self) -> MiscResourceBuilder {
+        MiscResourceBuilder { cgroup: self }
     }
 
     /// Finalize the control group, consuming the builder and creating the control group.
@@ -399,6 +404,51 @@ impl BlkIoResourcesBuilder {
     }
 
     /// Finish the construction of the blkio resources of a control group.
+    pub fn done(self) -> CgroupBuilder {
+        self.cgroup
+    }
+}
+
+/// A builder that configures the misc controller of a control group.
+pub struct MiscResourceBuilder {
+    cgroup: CgroupBuilder,
+}
+
+impl MiscResourceBuilder {
+    /// Set the maximum allowed usage of a misc resource (e.g. `"sev"`, `"sev_es"`, `"tdx"`).
+    /// Use `MiscMaxValue::Max` to leave a resource unconstrained.
+    pub fn limit(mut self, resource: &str, max: MiscMaxValue) -> MiscResourceBuilder {
+        self.cgroup
+            .resources
+            .misc
+            .maximum
+            .insert(resource.to_string(), max);
+        self
+    }
+
+    /// Convenience: set a numeric limit, e.g. `.limit_value("sev", 23)`.
+    ///
+    /// The limit is an unsigned 64-bit integer, matching the kernel misc ABI.
+    pub fn limit_value(mut self, resource: &str, max: u64) -> MiscResourceBuilder {
+        self.cgroup
+            .resources
+            .misc
+            .maximum
+            .insert(resource.to_string(), MiscMaxValue::Value(max));
+        self
+    }
+
+    /// Convenience: leave the resource unconstrained (`max`).
+    pub fn limit_max(mut self, resource: &str) -> MiscResourceBuilder {
+        self.cgroup
+            .resources
+            .misc
+            .maximum
+            .insert(resource.to_string(), MiscMaxValue::Max);
+        self
+    }
+
+    /// Finish the construction of the misc resources of a control group.
     pub fn done(self) -> CgroupBuilder {
         self.cgroup
     }

--- a/src/fs/hierarchies.rs
+++ b/src/fs/hierarchies.rs
@@ -19,6 +19,7 @@ use crate::fs::devices::DevicesController;
 use crate::fs::freezer::FreezerController;
 use crate::fs::hugetlb::HugeTlbController;
 use crate::fs::memory::MemController;
+use crate::fs::misc::MiscController;
 use crate::fs::net_cls::NetClsController;
 use crate::fs::net_prio::NetPrioController;
 use crate::fs::perf_event::PerfEventController;
@@ -167,6 +168,9 @@ impl Hierarchy for V1 {
         if let Some((point, root)) = self.get_mount_point(Controllers::Rdma) {
             subs.push(Subsystem::Rdma(RdmaController::new(point, root)));
         }
+        if let Some((point, root)) = self.get_mount_point(Controllers::Misc) {
+            subs.push(Subsystem::Misc(MiscController::new(point, root, false)));
+        }
         if let Some((point, root)) = self.get_mount_point(Controllers::Systemd) {
             subs.push(Subsystem::Systemd(SystemdController::new(
                 point, root, false,
@@ -268,6 +272,13 @@ impl Hierarchy for V2 {
                 }
                 "hugetlb" => {
                     subs.push(Subsystem::HugeTlb(HugeTlbController::new(
+                        self.root(),
+                        PathBuf::from(""),
+                        true,
+                    )));
+                }
+                "misc" => {
+                    subs.push(Subsystem::Misc(MiscController::new(
                         self.root(),
                         PathBuf::from(""),
                         true,
@@ -388,5 +399,20 @@ mod tests {
             let info = parse_mountinfo_for_line(mi.0).unwrap();
             assert_eq!(info, mi.1)
         }
+    }
+
+    #[test]
+    fn test_v1_subsystems_misc() {
+        let v1 = V1 {
+            mountinfo: vec![Mountinfo {
+                mount_root: PathBuf::from("/"),
+                mount_point: PathBuf::from("/sys/fs/cgroup/misc"),
+                fs_type: ("cgroup".to_string(), None),
+                super_opts: vec!["rw".to_string(), "misc".to_string()],
+            }],
+        };
+        let subs = v1.subsystems();
+        assert_eq!(subs.len(), 1);
+        assert_eq!(subs[0].controller_name(), "misc");
     }
 }

--- a/src/fs/misc.rs
+++ b/src/fs/misc.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
+//! This module contains the implementation of the `misc` cgroup subsystem.
+//!
+//! See the Kernel's documentation for more information about this subsystem, found at:
+//!  [Documentation/admin-guide/cgroup-v2.rst](https://docs.kernel.org/admin-guide/cgroup-v2.html#misc)
+
+use std::io::Write;
+use std::path::PathBuf;
+
+use crate::fs::error::*;
+use crate::fs::read_string_from;
+use crate::fs::{
+    ControllIdentifier, ControllerInternal, Controllers, MiscResources, Resources, Subsystem,
+};
+
+/// A controller that allows controlling the `misc` subsystem of a Cgroup.
+///
+/// In essence, using this controller one can limit and track miscellaneous
+/// scalar resources that cannot be abstracted like the other cgroup resources
+/// (e.g. `sev`, `sev_es`, `tdx`).
+///
+/// The misc controller is available on both cgroup v1 and v2 (kernel >= 5.13,
+/// `CONFIG_CGROUP_MISC`); the interface files are identical on both.
+#[derive(Debug, Clone)]
+pub struct MiscController {
+    base: PathBuf,
+    path: PathBuf,
+    // Records the hierarchy type; no behavior branches on it, as the misc
+    // interface files are identical on cgroup v1 and v2.
+    v2: bool,
+}
+
+impl ControllerInternal for MiscController {
+    fn control_type(&self) -> Controllers {
+        Controllers::Misc
+    }
+    fn get_path(&self) -> &PathBuf {
+        &self.path
+    }
+    fn get_path_mut(&mut self) -> &mut PathBuf {
+        &mut self.path
+    }
+    fn get_base(&self) -> &PathBuf {
+        &self.base
+    }
+
+    fn is_v2(&self) -> bool {
+        self.v2
+    }
+
+    fn apply(&self, res: &Resources) -> Result<()> {
+        // get the resources that apply to this controller
+        let res: &MiscResources = &res.misc;
+        for (name, val) in &res.maximum {
+            self.set_max(&format!("{} {}", name, val))?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ControllIdentifier for MiscController {
+    fn controller_type() -> Controllers {
+        Controllers::Misc
+    }
+}
+
+impl<'a> From<&'a Subsystem> for &'a MiscController {
+    fn from(sub: &'a Subsystem) -> &'a MiscController {
+        unsafe {
+            match sub {
+                Subsystem::Misc(c) => c,
+                _ => {
+                    assert_eq!(1, 0);
+                    let v = std::mem::MaybeUninit::uninit();
+                    v.assume_init()
+                }
+            }
+        }
+    }
+}
+
+impl MiscController {
+    /// Constructs a new `MiscController` with `root` serving as the root of the control group.
+    ///
+    /// Note that the `v2` flag is only informational: the misc interface files
+    /// are identical on cgroup v1 and v2, so no behavior depends on it.
+    pub fn new(point: PathBuf, root: PathBuf, v2: bool) -> Self {
+        Self {
+            base: root,
+            path: point,
+            v2,
+        }
+    }
+
+    /// Returns the available quantity of each misc resource on the host.
+    ///
+    /// Note: `misc.capacity` is only shown in the root cgroup; reading it from
+    /// a non-root cgroup fails.
+    pub fn capacity(&self) -> Result<String> {
+        self.open_path("misc.capacity", false)
+            .and_then(read_string_from)
+    }
+
+    /// Returns the current usage of each misc resource in the cgroup and its children.
+    pub fn current(&self) -> Result<String> {
+        self.open_path("misc.current", false)
+            .and_then(read_string_from)
+    }
+
+    /// Returns the historical maximum (peak) usage of each misc resource in the
+    /// cgroup and its children.
+    ///
+    /// Note: `misc.peak` was added in Linux 6.11; reading it on older kernels fails.
+    pub fn peak(&self) -> Result<String> {
+        self.open_path("misc.peak", false)
+            .and_then(read_string_from)
+    }
+
+    /// Returns the maximum allowed usage of each misc resource in the cgroup
+    /// and its children.
+    ///
+    /// Note: `misc.max` is only shown in non-root cgroups.
+    pub fn max(&self) -> Result<String> {
+        self.open_path("misc.max", false).and_then(read_string_from)
+    }
+
+    /// Sets the maximum allowed usage of a misc resource.
+    ///
+    /// `line` is a single `"<resource> <limit>"` pair, where `<limit>` is a
+    /// number or `max` (no limit), e.g. `set_max("sev 5")`. The limit may be
+    /// set higher than the resource's capacity.
+    ///
+    /// Note: `misc.max` only exists in non-root cgroups.
+    pub fn set_max(&self, line: &str) -> Result<()> {
+        self.open_path("misc.max", true).and_then(|mut file| {
+            file.write_all(line.as_ref()).map_err(|e| {
+                Error::with_cause(
+                    ErrorKind::WriteFailed("misc.max".to_string(), line.to_string()),
+                    e,
+                )
+            })
+        })
+    }
+
+    /// Returns the number of times each resource's usage was about to go over
+    /// its max boundary. The counts are hierarchical, i.e. they include the
+    /// events of all descendant cgroups.
+    ///
+    /// The output is one `<resource>.max <count>` line per resource.
+    ///
+    /// Note: `misc.events` was added in Linux 5.16 and is only shown in
+    /// non-root cgroups.
+    pub fn events(&self) -> Result<String> {
+        self.open_path("misc.events", false)
+            .and_then(read_string_from)
+    }
+
+    /// Like [`MiscController::events`], but only counting events local to this
+    /// cgroup itself.
+    ///
+    /// Note: `misc.events.local` was added in Linux 6.11 and is only shown in
+    /// non-root cgroups.
+    pub fn events_local(&self) -> Result<String> {
+        self.open_path("misc.events.local", false)
+            .and_then(read_string_from)
+    }
+}

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -45,6 +45,7 @@ pub mod freezer;
 pub mod hierarchies;
 pub mod hugetlb;
 pub mod memory;
+pub mod misc;
 pub mod net_cls;
 pub mod net_prio;
 pub mod perf_event;
@@ -62,6 +63,7 @@ use crate::fs::error::*;
 use crate::fs::freezer::FreezerController;
 use crate::fs::hugetlb::HugeTlbController;
 use crate::fs::memory::MemController;
+use crate::fs::misc::MiscController;
 use crate::fs::net_cls::NetClsController;
 use crate::fs::net_prio::NetPrioController;
 use crate::fs::perf_event::PerfEventController;
@@ -101,6 +103,8 @@ pub enum Subsystem {
     HugeTlb(HugeTlbController),
     /// Controller for the `Rdma` subsystem, see `RdmaController` for more information.
     Rdma(RdmaController),
+    /// Controller for the `Misc` subsystem, see `MiscController` for more information.
+    Misc(MiscController),
     /// Controller for the `Systemd` subsystem, see `SystemdController` for more information.
     Systemd(SystemdController),
 }
@@ -121,6 +125,7 @@ pub enum Controllers {
     NetPrio,
     HugeTlb,
     Rdma,
+    Misc,
     Systemd,
 }
 
@@ -140,6 +145,7 @@ impl fmt::Display for Controllers {
             Controllers::NetPrio => write!(f, "net_prio"),
             Controllers::HugeTlb => write!(f, "hugetlb"),
             Controllers::Rdma => write!(f, "rdma"),
+            Controllers::Misc => write!(f, "misc"),
             Controllers::Systemd => write!(f, "name=systemd"),
         }
     }
@@ -734,6 +740,14 @@ pub struct BlkIoResources {
     pub attrs: HashMap<String, String>,
 }
 
+/// Resource limits on miscellaneous scalar resources (e.g. SEV, SEV-ES, TDX).
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MiscResources {
+    /// The maximum allowed capacity for each scalar resource in the control group.
+    pub maximum: HashMap<String, MiscMaxValue>,
+}
+
 /// The resource limits and constraints that will be set on the control group.
 #[derive(Debug, Clone, Eq, PartialEq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -752,6 +766,11 @@ pub struct Resources {
     pub hugepages: HugePageResources,
     /// Block device I/O related limits.
     pub blkio: BlkIoResources,
+    /// Scalar resources related limits.
+    // serde(default): configs serialized before this field was added do not
+    // contain it and must still deserialize.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub misc: MiscResources,
 }
 
 impl Subsystem {
@@ -809,6 +828,10 @@ impl Subsystem {
                 cont.get_path_mut().push(path);
                 cont
             }),
+            Subsystem::Misc(mut cont) => Subsystem::Misc({
+                cont.get_path_mut().push(path);
+                cont
+            }),
             Subsystem::Systemd(mut cont) => Subsystem::Systemd({
                 cont.get_path_mut().push(path);
                 cont
@@ -831,6 +854,7 @@ impl Subsystem {
             Subsystem::NetPrio(cont) => cont,
             Subsystem::HugeTlb(cont) => cont,
             Subsystem::Rdma(cont) => cont,
+            Subsystem::Misc(cont) => cont,
             Subsystem::Systemd(cont) => cont,
         }
     }
@@ -883,6 +907,36 @@ pub fn parse_max_value(s: &str) -> Result<MaxValue> {
     match s.trim().parse() {
         Ok(val) => Ok(MaxValue::Value(val)),
         Err(e) => Err(Error::with_cause(ParseError, e)),
+    }
+}
+
+/// The maximum allowed usage of a misc resource (`misc.max`).
+///
+/// Unlike [`MaxValue`], the limit is an unsigned 64-bit integer, matching the
+/// kernel misc ABI (`kstrtou64()`): negative values are rejected by the
+/// kernel, and limits above `i64::MAX` are representable.
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum MiscMaxValue {
+    /// This value is used to leave the resource unconstrained.
+    Max,
+    /// When the value is a numerical value, it is passed via this enum field.
+    Value(u64),
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for MiscMaxValue {
+    fn default() -> Self {
+        MiscMaxValue::Max
+    }
+}
+
+impl fmt::Display for MiscMaxValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MiscMaxValue::Max => write!(f, "max"),
+            MiscMaxValue::Value(num) => write!(f, "{}", num),
+        }
     }
 }
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -11,6 +11,7 @@ use cgroups_rs::fs::cpu::*;
 use cgroups_rs::fs::devices::*;
 use cgroups_rs::fs::hugetlb::*;
 use cgroups_rs::fs::memory::*;
+use cgroups_rs::fs::misc::*;
 use cgroups_rs::fs::net_cls::*;
 use cgroups_rs::fs::pid::*;
 use cgroups_rs::fs::*;
@@ -164,6 +165,36 @@ pub fn test_blkio_res_build() {
     {
         let c: &BlkIoController = cg.controller_of().unwrap();
         assert_eq!(c.blkio().weight, 100);
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+pub fn test_misc_res_build() {
+    let h = cgroups_rs::fs::hierarchies::auto();
+    if !h.v2() {
+        return;
+    }
+
+    let root_misc = MiscController::new(
+        std::path::PathBuf::from("/sys/fs/cgroup"),
+        std::path::PathBuf::from("/sys/fs/cgroup"),
+        true,
+    );
+    let capacity = root_misc.capacity().unwrap_or_default();
+    let first_res = capacity
+        .lines()
+        .find_map(|line| line.split_whitespace().next());
+
+    let mut builder = CgroupBuilder::new("test_misc_res_build").misc();
+    if let Some(res_name) = first_res {
+        builder = builder.limit_max(res_name);
+    }
+    let cg: Cgroup = builder.done().build(h).unwrap();
+
+    let c: Option<&MiscController> = cg.controller_of();
+    if let Some(c) = c {
+        let _ = c.max();
     }
     cg.delete().unwrap();
 }

--- a/tests/misc.rs
+++ b/tests/misc.rs
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0 or MIT
+//
+
+//! Tests for the misc cgroup subsystem.
+
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use cgroups_rs::fs::misc::MiscController;
+use cgroups_rs::fs::{Cgroup, Controller, MiscMaxValue, MiscResources, Resources};
+
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn test_dir() -> PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "cgroups-rs-misc-test-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::SeqCst)
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+#[test]
+fn test_misc_controller_read_files() {
+    let dir = test_dir();
+
+    fs::write(dir.join("misc.capacity"), "sev 50\nsev_es 100\n").unwrap();
+    fs::write(dir.join("misc.current"), "sev 10\nsev_es 20\n").unwrap();
+    fs::write(dir.join("misc.peak"), "sev 15\nsev_es 25\n").unwrap();
+    fs::write(dir.join("misc.max"), "sev 40\nsev_es max\n").unwrap();
+    fs::write(dir.join("misc.events"), "sev.max 2\n").unwrap();
+    fs::write(dir.join("misc.events.local"), "sev.max 1\n").unwrap();
+
+    let controller = MiscController::new(dir.clone(), dir.clone(), true);
+
+    assert_eq!(controller.capacity().unwrap(), "sev 50\nsev_es 100");
+    assert_eq!(controller.current().unwrap(), "sev 10\nsev_es 20");
+    assert_eq!(controller.peak().unwrap(), "sev 15\nsev_es 25");
+    assert_eq!(controller.max().unwrap(), "sev 40\nsev_es max");
+    assert_eq!(controller.events().unwrap(), "sev.max 2");
+    assert_eq!(controller.events_local().unwrap(), "sev.max 1");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_controller_set_max() {
+    let dir = test_dir();
+    let max_file = dir.join("misc.max");
+    File::create(&max_file).unwrap();
+
+    let controller = MiscController::new(dir.clone(), dir.clone(), true);
+    controller.set_max("sev 42").unwrap();
+
+    let content = fs::read_to_string(&max_file).unwrap();
+    assert_eq!(content, "sev 42");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_controller_apply() {
+    let dir = test_dir();
+    let max_file = dir.join("misc.max");
+    File::create(&max_file).unwrap();
+
+    let controller = MiscController::new(dir.clone(), dir.clone(), true);
+
+    let mut maximum = HashMap::new();
+    maximum.insert("sev".to_string(), MiscMaxValue::Value(123));
+
+    let res = Resources {
+        misc: MiscResources { maximum },
+        ..Default::default()
+    };
+
+    controller.apply(&res).unwrap();
+
+    let content = fs::read_to_string(&max_file).unwrap();
+    assert_eq!(content, "sev 123");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_controller_apply_max() {
+    let dir = test_dir();
+    let max_file = dir.join("misc.max");
+    File::create(&max_file).unwrap();
+
+    let controller = MiscController::new(dir.clone(), dir.clone(), true);
+
+    let mut maximum = HashMap::new();
+    maximum.insert("sev".to_string(), MiscMaxValue::Max);
+
+    let res = Resources {
+        misc: MiscResources { maximum },
+        ..Default::default()
+    };
+
+    controller.apply(&res).unwrap();
+
+    let content = fs::read_to_string(&max_file).unwrap();
+    assert_eq!(content, "sev max");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_controller_apply_empty() {
+    let dir = test_dir();
+    let max_file = dir.join("misc.max");
+    File::create(&max_file).unwrap();
+
+    let controller = MiscController::new(dir.clone(), dir.clone(), true);
+
+    // No misc limits: apply must be a no-op and leave misc.max untouched.
+    controller.apply(&Resources::default()).unwrap();
+
+    let content = fs::read_to_string(&max_file).unwrap();
+    assert_eq!(content, "");
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_controller_read_missing_files() {
+    let dir = test_dir();
+    // The cgroup directory itself does not exist: all reads must fail.
+    let missing = dir.join("no-such-cgroup");
+    let controller = MiscController::new(missing, dir.clone(), true);
+
+    assert!(controller.capacity().is_err());
+    assert!(controller.current().is_err());
+    assert!(controller.peak().is_err());
+    assert!(controller.max().is_err());
+    assert!(controller.events().is_err());
+    assert!(controller.events_local().is_err());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_controller_set_max_missing_dir() {
+    let dir = test_dir();
+    // The cgroup directory itself does not exist: creating misc.max fails.
+    let missing = dir.join("no-such-cgroup");
+    let controller = MiscController::new(missing, dir.clone(), true);
+
+    assert!(controller.set_max("sev 1").is_err());
+
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn test_misc_cgroup_create_and_delete() {
+    // Runs on both v1 and v2: on v1 it exercises the legacy misc hierarchy
+    // when it is mounted; when misc is not available, `controller_of` returns
+    // None and the reads are skipped.
+    let h = cgroups_rs::fs::hierarchies::auto();
+    let cg = Cgroup::new(h, String::from("test_misc_cgroup_create_and_delete")).unwrap();
+    {
+        let controller: Option<&MiscController> = cg.controller_of();
+        if let Some(c) = controller {
+            let _ = c.current();
+            let _ = c.max();
+        }
+    }
+    cg.delete().unwrap();
+}

--- a/tests/resources.rs
+++ b/tests/resources.rs
@@ -5,8 +5,10 @@
 //
 
 //! Integration test about setting resources using `apply()`
+use std::collections::HashMap;
+
 use cgroups_rs::fs::pid::PidController;
-use cgroups_rs::fs::{Cgroup, MaxValue, PidResources, Resources};
+use cgroups_rs::fs::{Cgroup, MaxValue, MiscMaxValue, MiscResources, PidResources, Resources};
 
 #[test]
 fn pid_resources() {
@@ -26,6 +28,35 @@ fn pid_resources() {
         let pid_max = pidcontroller.get_pid_max();
         assert!(pid_max.is_ok());
         assert_eq!(pid_max.unwrap(), MaxValue::Value(512));
+    }
+    cg.delete().unwrap();
+}
+
+#[test]
+fn misc_resources() {
+    let h = cgroups_rs::fs::hierarchies::auto();
+
+    let root_misc = cgroups_rs::fs::misc::MiscController::new(
+        std::path::PathBuf::from("/sys/fs/cgroup"),
+        std::path::PathBuf::from("/sys/fs/cgroup"),
+        true,
+    );
+    let capacity = root_misc.capacity().unwrap_or_default();
+    let first_res = capacity
+        .lines()
+        .find_map(|line| line.split_whitespace().next());
+
+    let cg = Cgroup::new(h, String::from("misc_resources")).unwrap();
+    {
+        let mut maximum = HashMap::new();
+        if let Some(res_name) = first_res {
+            maximum.insert(res_name.to_string(), MiscMaxValue::Max);
+        }
+        let res = Resources {
+            misc: MiscResources { maximum },
+            ..Default::default()
+        };
+        cg.apply(&res).unwrap();
     }
     cg.delete().unwrap();
 }


### PR DESCRIPTION
Introduce the `misc` controller in `cgroups::fs` for tracking and limiting miscellaneous scalar resources (such as SEV, SEV-ES, and TDX) across both cgroup v1 and v2.

The `MiscController` implements `ControllerInternal` and exposes methods to query `misc.capacity` (root cgroup), `misc.current`, `misc.peak`, `misc.max`, `misc.events`, and `misc.events.local`. Writing resource limits is supported via `set_max`.

Extend `Resources` with `MiscResources` and `MiscMaxValue` (supporting `u64` limits to match the kernel `kstrtou64()` ABI, and `max` for unconstrained usage). Add `MiscResourceBuilder` under `CgroupBuilder` to allow fluent configuration. Hierarchy discovery is updated to recognize the `misc` subsystem on both v1 and v2.

Add unit and integration tests covering controller file reads/writes, missing directory errors, resource application, and builder integration.

Closes https://github.com/kata-containers/cgroups-rs/issues/84.